### PR TITLE
fix(ci): unblock main pipeline (fmt drift, flaky job-id, auto-install hook)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,12 @@ frontend Vitest suite at the repo root.
 One-time per clone:
 
 ```sh
-npm install
+npm install                         # also runs scripts/install-hooks.sh via "prepare"
+```
+
+If you ever need to re-register the hook manually:
+
+```sh
 bash scripts/install-hooks.sh       # registers .githooks/pre-commit
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/antimatter-studios/diskcutter.git"
   },
   "scripts": {
+    "prepare": "./scripts/install-hooks.sh || true",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -571,7 +571,10 @@ mod tests {
         assert!(obj.contains_key("chunk.bytes"));
         assert!(!obj.contains_key("language"));
         assert!(!obj.contains_key("theme"));
-        assert!(!obj.contains_key("verify.skip"), "empty-string values stay out");
+        assert!(
+            !obj.contains_key("verify.skip"),
+            "empty-string values stay out"
+        );
     }
 
     #[test]
@@ -597,8 +600,16 @@ mod tests {
     #[test]
     fn record_burn_started_inserts_running_row_and_log() {
         let db = fresh_db();
-        let id = record_burn_started(&db, "job-1", "/tmp/x.iso", "x.iso", 12345, "/dev/disk5", "{}")
-            .expect("insert returns id");
+        let id = record_burn_started(
+            &db,
+            "job-1",
+            "/tmp/x.iso",
+            "x.iso",
+            12345,
+            "/dev/disk5",
+            "{}",
+        )
+        .expect("insert returns id");
         let rows = burn_history_list_impl(&db, None).unwrap();
         assert_eq!(rows.len(), 1);
         let r = &rows[0];
@@ -621,8 +632,16 @@ mod tests {
     #[test]
     fn record_burn_completed_marks_success_and_appends_log() {
         let db = fresh_db();
-        let id =
-            record_burn_started(&db, "job-ok", "/tmp/x.iso", "x.iso", 100, "/dev/disk5", "{}").unwrap();
+        let id = record_burn_started(
+            &db,
+            "job-ok",
+            "/tmp/x.iso",
+            "x.iso",
+            100,
+            "/dev/disk5",
+            "{}",
+        )
+        .unwrap();
         record_burn_completed(
             &db, "job-ok", "src-hash", "rb-hash", true, 100, 1500, 1000, 2000,
         );
@@ -650,8 +669,16 @@ mod tests {
     #[test]
     fn record_burn_completed_marks_error_on_hash_mismatch() {
         let db = fresh_db();
-        let id =
-            record_burn_started(&db, "job-mm", "/tmp/x.iso", "x.iso", 100, "/dev/disk5", "{}").unwrap();
+        let id = record_burn_started(
+            &db,
+            "job-mm",
+            "/tmp/x.iso",
+            "x.iso",
+            100,
+            "/dev/disk5",
+            "{}",
+        )
+        .unwrap();
         record_burn_completed(&db, "job-mm", "a", "b", false, 100, 100, 100, 100);
         let rows = burn_history_list_impl(&db, None).unwrap();
         let r = &rows[0];
@@ -666,8 +693,16 @@ mod tests {
     #[test]
     fn record_burn_failed_marks_error_and_logs() {
         let db = fresh_db();
-        let id =
-            record_burn_started(&db, "job-fail", "/tmp/x.iso", "x.iso", 0, "/dev/disk5", "{}").unwrap();
+        let id = record_burn_started(
+            &db,
+            "job-fail",
+            "/tmp/x.iso",
+            "x.iso",
+            0,
+            "/dev/disk5",
+            "{}",
+        )
+        .unwrap();
         record_burn_failed(&db, "job-fail", "EIO", "boom");
         let r = &burn_history_list_impl(&db, None).unwrap()[0];
         assert_eq!(r.state, "error");
@@ -699,7 +734,8 @@ mod tests {
     #[test]
     fn append_log_appends_for_running_job_only() {
         let db = fresh_db();
-        let id = record_burn_started(&db, "job-l", "/tmp/x.iso", "x.iso", 0, "/dev/disk5", "{}").unwrap();
+        let id = record_burn_started(&db, "job-l", "/tmp/x.iso", "x.iso", 0, "/dev/disk5", "{}")
+            .unwrap();
         append_log(&db, "job-l", "warn", "yellow");
         // No-op against an unknown job_id.
         append_log(&db, "no-such", "warn", "ignored");
@@ -753,7 +789,8 @@ mod tests {
     #[test]
     fn burn_history_clear_empties_table_and_cascades_to_logs() {
         let db = fresh_db();
-        let id = record_burn_started(&db, "job-x", "/tmp/x.iso", "x.iso", 0, "/dev/disk5", "{}").unwrap();
+        let id = record_burn_started(&db, "job-x", "/tmp/x.iso", "x.iso", 0, "/dev/disk5", "{}")
+            .unwrap();
         record_burn_completed(&db, "job-x", "s", "r", true, 1, 1, 1, 1);
         assert_eq!(burn_history_list_impl(&db, None).unwrap().len(), 1);
         assert!(!burn_logs_list_impl(&db, id).unwrap().is_empty());
@@ -768,8 +805,10 @@ mod tests {
     #[test]
     fn burn_logs_list_filters_by_burn_id_and_orders_ascending() {
         let db = fresh_db();
-        let id1 = record_burn_started(&db, "j1", "/tmp/x.iso", "x.iso", 0, "/dev/disk5", "{}").unwrap();
-        let id2 = record_burn_started(&db, "j2", "/tmp/y.iso", "y.iso", 0, "/dev/disk6", "{}").unwrap();
+        let id1 =
+            record_burn_started(&db, "j1", "/tmp/x.iso", "x.iso", 0, "/dev/disk5", "{}").unwrap();
+        let id2 =
+            record_burn_started(&db, "j2", "/tmp/y.iso", "y.iso", 0, "/dev/disk6", "{}").unwrap();
         append_log(&db, "j1", "info", "one");
         append_log(&db, "j1", "info", "two");
         append_log(&db, "j2", "warn", "other");

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -341,12 +341,14 @@ fn enumerate_macos() -> Option<Vec<Disk>> {
     Some(out)
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn is_whole_disk(id: &str) -> bool {
     id.strip_prefix("disk")
         .map(|n| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
         .unwrap_or(false)
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn parse_disks_plist(bytes: &[u8]) -> Option<Vec<String>> {
     let val: plist::Value = plist::from_bytes(bytes).ok()?;
     let all = val.as_dictionary()?.get("AllDisks")?.as_array()?;
@@ -374,6 +376,7 @@ fn info_for_macos(id: &str) -> Option<Disk> {
     parse_disk_info_plist(&out.stdout, path)
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn parse_disk_info_plist(bytes: &[u8], device_path: String) -> Option<Disk> {
     let val: plist::Value = plist::from_bytes(bytes).ok()?;
     let dict = val.as_dictionary()?;
@@ -637,6 +640,7 @@ fn format_capacity(bytes: u64) -> String {
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn derive_partitions(dict: &plist::Dictionary) -> String {
     let fs = dict
         .get("FilesystemType")

--- a/src-tauri/src/doctor.rs
+++ b/src-tauri/src/doctor.rs
@@ -12,6 +12,7 @@
 //! Hard rule: every check must complete in well under a second. We
 //! call this on UI mount and the user shouldn't notice.
 
+#[cfg(target_os = "macos")]
 use std::path::Path;
 use std::process::{Command, Stdio};
 

--- a/src-tauri/src/forensic.rs
+++ b/src-tauri/src/forensic.rs
@@ -139,10 +139,7 @@ pub fn build_report(burn: &BurnRecord, logs: &[BurnLogRow], host: HostInfo) -> F
         error_message: burn.error_message.clone(),
         started_at_unix_ms: burn.started_at,
         finished_at_unix_ms: burn.finished_at,
-        burn_params: burn
-            .burn_params
-            .as_deref()
-            .and_then(parse_burn_params_json),
+        burn_params: burn.burn_params.as_deref().and_then(parse_burn_params_json),
     };
     let log_entries: Vec<LogEntry> = logs
         .iter()

--- a/src-tauri/src/writers/block.rs
+++ b/src-tauri/src/writers/block.rs
@@ -6,7 +6,7 @@
 use std::fs::{File, OpenOptions};
 #[cfg(unix)]
 use std::io::{Read, Result, Write};
-#[cfg(unix)]
+#[cfg(target_os = "macos")]
 use std::os::unix::fs::OpenOptionsExt;
 #[cfg(unix)]
 use std::path::{Path, PathBuf};

--- a/src-tauri/src/writers/raw.rs
+++ b/src-tauri/src/writers/raw.rs
@@ -103,6 +103,7 @@ fn unmount_macos(device: &Path) -> std::result::Result<(), String> {
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
+#[allow(dead_code)]
 fn unmount_macos(_device: &Path) -> std::result::Result<(), String> {
     Ok(())
 }

--- a/src/format.js
+++ b/src/format.js
@@ -31,7 +31,7 @@ export function formatSession(ms) {
 
 export function makeJob(num, image, target, parentEntryId) {
   return {
-    id: `job-${Date.now()}-${num}`,
+    id: `job-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     num,
     image,
     target,


### PR DESCRIPTION
## Summary

Brings main's CI green again (run [25916621561](https://github.com/antimatter-studios/diskcutter/actions/runs/25916621561) had 3 reds) and prevents the same class of breakage from landing again.

- **style:** apply `cargo fmt` to `db/mod.rs` (call-site formatting around `record_burn_started`, 8 sites) and `forensic.rs` — fixes `cargo fmt --check` on ubuntu + macos.
- **fix(format):** `makeJob` was building ids as `job-${Date.now()}-${num}`, which collides for two calls in the same ms with the same `num`. Switch to a 6-char base36 suffix (same shape as `makeEntry`), matches the existing `/^job-\d+-[a-z0-9]+$/` regex. Fixes vitest flake `tests/format.test.js:102`.
- **chore(hooks):** wire `scripts/install-hooks.sh` into a `prepare` npm script so `npm install` auto-registers `.githooks/pre-commit`. The hook (i18n + fmt + clippy) already existed but had to be installed manually on every fresh clone, which is how the fmt drift slipped past pre-commit on this side and landed on main.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `npx vitest run` — 217/217 passing
- [x] `node scripts/check-i18n.mjs` — all locales in parity
- [x] Hook fires on every commit on this branch (visible in commit output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)