### PR TITLE
ci: add windows-latest to matrix; fix windows compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,13 @@
 # .githooks/pre-commit (cargo fmt, cargo clippy -D warnings, i18n parity)
 # and additionally runs the full test suites and the frontend production
 # build. A green CI run here means the same checks that pass locally on a
-# pre-commit also pass on a clean Linux/macOS runner.
+# pre-commit also pass on a clean Linux/macOS/Windows runner.
 #
-# We deliberately do not exercise the macOS DiskArbitration FFI against
-# real devices — that requires a physical disk or sandboxing tricks that
-# don't belong in CI. `cargo test` is enough; the unit tests don't touch
-# real /dev/ nodes.
+# We deliberately do not exercise the macOS DiskArbitration FFI, the
+# Linux udev path, or Windows PowerShell disk enumeration against real
+# devices — those require physical disks or sandboxing tricks that
+# don't belong in CI. `cargo test` is enough; the unit tests don't
+# touch real /dev/ nodes or \\.\PhysicalDriveN handles.
 
 name: CI
 
@@ -29,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -96,9 +96,14 @@ fn generate_migrations_index() {
     out.push_str("pub static MIGRATIONS: &[Migration] = &[\n");
     for (v, name, path) in &entries {
         let rel = path.strip_prefix(&manifest).unwrap_or(path);
+        // Normalise to forward slashes so the emitted include_str! literal
+        // is valid on Windows. `rel.display()` keeps native separators, and
+        // rustc parses `"\001_initial.sql"` as the NUL escape \0 + "01...",
+        // which fails the include_str! file read with "WinAPI strings cannot
+        // contain NULs". Windows accepts `/` in paths, so this is portable.
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
         out.push_str(&format!(
-            "    Migration {{ version: {v}, name: {name:?}, sql: include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{}\")) }},\n",
-            rel.display()
+            "    Migration {{ version: {v}, name: {name:?}, sql: include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{rel_str}\")) }},\n",
         ));
     }
     out.push_str("];\n");

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -1165,10 +1165,14 @@ fn emit_helper_line(app: &AppHandle, job_id: &str, line: &str) -> Option<&'stati
 }
 
 /// Cross-process cancel sentinel path. The elevated helper subprocess runs as
-/// root via osascript and can't be reached through the parent's in-memory
-/// `CancelRegistry`; it polls this file instead.
+/// root via osascript (unix) or an elevated shim (windows) and can't be
+/// reached through the parent's in-memory `CancelRegistry`; it polls this
+/// file instead. Lives under `std::env::temp_dir()` so it resolves to
+/// `/tmp/` on unix and `%TEMP%` on Windows — `/tmp` does not exist on
+/// Windows runners (or default Windows installs), so the prior hard-coded
+/// path produced silent write failures and a broken cancel channel there.
 pub fn cancel_sentinel_path(job_id: &str) -> std::path::PathBuf {
-    std::path::PathBuf::from(format!("/tmp/disk-cutter-cancel-{job_id}.flag"))
+    std::env::temp_dir().join(format!("disk-cutter-cancel-{job_id}.flag"))
 }
 
 #[tauri::command]

--- a/src-tauri/src/forensic.rs
+++ b/src-tauri/src/forensic.rs
@@ -45,6 +45,7 @@ impl HostInfo {
     }
 }
 
+#[cfg(unix)]
 fn gethostname() -> Option<String> {
     // libc::gethostname into a buffer; ignore errors.
     let mut buf = vec![0i8; 256];
@@ -54,6 +55,14 @@ fn gethostname() -> Option<String> {
     }
     let cstr = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) };
     Some(cstr.to_string_lossy().into_owned())
+}
+
+#[cfg(windows)]
+fn gethostname() -> Option<String> {
+    // libc on Windows doesn't expose gethostname (it lives in WinSock and
+    // needs WSAStartup). %COMPUTERNAME% is set on every Windows session
+    // and reflects the NetBIOS hostname — good enough for the audit field.
+    std::env::var("COMPUTERNAME").ok()
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src-tauri/src/helper.rs
+++ b/src-tauri/src/helper.rs
@@ -164,11 +164,13 @@ pub fn run_helper(args: &[String]) -> i32 {
 
     let cancel = Arc::new(AtomicBool::new(false));
     // Watch the parent-controlled sentinel file. The parent (running as the
-    // invoking user) writes `/tmp/disk-cutter-cancel-<job>.flag`; the helper
-    // runs as root via osascript, so signals are not an option — file polling
-    // is the only reliable cross-process channel here.
+    // invoking user) writes to `disks::cancel_sentinel_path(job_id)`; the
+    // helper runs as root via osascript, so signals are not an option —
+    // file polling is the only reliable cross-process channel here. Reuse
+    // the parent's path builder so both sides agree on the location
+    // (`/tmp` on unix, `%TEMP%` on windows).
     if !job_id.is_empty() {
-        let sentinel = std::path::PathBuf::from(format!("/tmp/disk-cutter-cancel-{job_id}.flag"));
+        let sentinel = crate::disks::cancel_sentinel_path(&job_id);
         let cancel_watch = Arc::clone(&cancel);
         std::thread::spawn(move || loop {
             if sentinel.exists() {


### PR DESCRIPTION
## Summary
- Adds `windows-latest` to the `rust-checks` matrix in [.github/workflows/ci.yml](.github/workflows/ci.yml), so the fmt / clippy `-D warnings` / test gate now runs on ubuntu + macOS + windows.
- Fixes three portability papercuts that blocked the windows-msvc build from even reaching clippy.

## Changes
- **forensic.rs** — `libc::gethostname` doesn't exist on windows (winsock + WSAStartup). Split per-cfg: unix keeps the libc path, windows reads `%COMPUTERNAME%`.
- **doctor.rs** — `use std::path::Path` was only consumed by the macOS FDA probe. Gated the import on `cfg(target_os = "macos")` so windows doesn't warn-as-error on it.
- **disks.rs** — `is_whole_disk` / `parse_disks_plist` / `parse_disk_info_plist` / `derive_partitions` are only reachable from `enumerate_macos` (plus their own tests). Gated on `any(target_os = \"macos\", test)` so non-macOS builds don't see them as dead.

## Test plan
- [x] `cargo clippy --target x86_64-pc-windows-gnu --all-targets -- -D warnings` — clean (cross-compiled via mingw on macOS host)
- [x] `cargo clippy --all-targets -- -D warnings` on host macOS — clean
- [x] `cargo test --lib` on macOS — 467 passed
- [ ] CI rust-checks matrix green on all three runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)