### PR TITLE
feat: per-row debug log + image scan cache + compressed probe fix

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -72,3 +72,81 @@ Today an encrypted image would fail with a generic `Error::Unsupported`. Disk Cu
 ### Considered, not pursued
 
 - **Async / tokio support in the qcow2 crate** — Disk Cutter runs reads on `std::thread::spawn`. No tokio surface needed.
+
+### Image-scan caching — phased plan
+
+We currently slurp a 4 MiB prefix at row-expand time and run the partition / boot
+probes over it. Per-partition filesystem labels for compressed sources need bytes
+past the prefix, and a future "extract one partition to a target's empty region"
+feature needs the full partition bytes. Work is phased so each step solves a real
+problem without over-building.
+
+**Phase 1 (in progress)** — `image_scans` table + eager-on-add single-pass scan
++ progressive UI events. Triggered when the user adds an image (or clicks
+REFRESH); not lazy on row-expand — the disk cost is small (partition samples
+only, ~hundreds of KB) and we'd rather have the data ready by the time the
+user picks a target. One sequential decompression per `(image_path, size,
+mtime)`, stopping at `last_partition_start + 64 KB`. Outputs cached: format
+chain, true uncompressed size (xz only — see trade-off note below),
+partition table, per-partition filesystem labels, boot sources. Cached row
+shared across every burn_job pointing at the same image path, so adding the
+same image to 10 burn_jobs scans once.
+
+**Phase 1 trade-offs to revisit:**
+- Source SHA-256 is *not* computed (would require draining the full stream).
+  The user-facing "SHA-256 (SOURCE)" KV was removed from the queue UI, so this
+  has no immediate cost; revisit if the field returns or if the burn pipeline
+  ever wants to skip its own source-hash pass.
+- True uncompressed size is *only* recoverable for xz (footer index parsed
+  via `xz_footer::read_total_uncompressed`). gzip / bzip2 / zstd report the
+  compressed file size as an over-conservative placeholder — fine for the
+  progress bar's "we've at least decoded this much" denominator, less fine
+  for an exact value to display. Revisit if the UI starts depending on
+  exact decompressed bytes for a non-xz compressed source.
+
+**Phase 2 (deferred)** — temp-file materialization for compressed multi-copy
+queues only. Decisions locked in:
+
+  1. **Trigger**: only when the queue entry has `copies > 1`. Single-copy
+     burns stream-decompress as today.
+  2. **Timing**: temp file is materialized when the burn process *begins*,
+     not when the image is added to the queue. Avoids the worst case of
+     "user adds 10 × 31 GB images = 310 GB temp on queue-add."
+  3. **Location**: `~/Library/Caches/com.antimatter-studios.diskcutter/scratch/`
+     on macOS; OS-equivalents elsewhere; pref-overridable.
+  4. **Cleanup**: ref-counted — temp file lives until the last burn from
+     that queue entry's copy-pool finishes (success / error / cancelled).
+  5. **Disk-space guardrail**: refuse and warn before materializing if
+     we'd consume more than 50% of free space on the cache volume.
+
+Once Phase 2 lands, the offset-map / per-format restart-point machinery from
+Phase 3 below becomes obsolete for any image that's been materialized.
+
+**Phase 3 (deferred until a feature needs it)** — partition extraction without
+full materialization. Add per-format restart points (xz native block index,
+bzip2 magic-marker scan, zstd frame boundaries, gzip zran-style window
+snapshots) so a single partition can be extracted from a compressed source
+without decompressing the whole file or keeping a temp `.img`. Only relevant
+on systems where temp-file materialization is undesirable (low disk, sealed
+storage). The gzip leg is the expensive one — needs a gzip lib that can
+resume from injected window state, or a fallback to Phase 2.
+
+The clean shape for this: a `DiskOffset` trait alongside the existing
+`FormatTryOpen` / `ReaderInterface`, one impl per format:
+
+```rust
+pub trait DiskOffset: Send + Sync {
+    fn to_json(&self) -> serde_json::Value;
+    fn open_at(&self, path: &Path) -> io::Result<Box<dyn ReaderInterface>>;
+}
+```
+
+Each format stores only what it needs (xz/bzip2/zstd: 8 bytes; gzip:
+8 bytes + 32 KB window snapshot). Consumers call `offset.open_at(path)`
+and drain — format-specific machinery stays encapsulated. The
+`image_scans.partition_offsets` column is the persistence target.
+
+**Future feature this all enables**: "write one partition from a disk image
+to an empty region of the target drive, without wiping the rest." Phase 2 is
+sufficient (random-access on the temp file); Phase 3 is the disk-frugal
+alternative.

--- a/src-tauri/migrations/0003_image_scans.sql
+++ b/src-tauri/migrations/0003_image_scans.sql
@@ -1,0 +1,46 @@
+-- 0003_image_scans.sql
+-- One-row-per-image cache of the deep scan results so adding the same image
+-- to multiple burn_jobs only pays the decompression cost once.
+--
+-- Rows are keyed by `image_path` and freshness is verified on read by
+-- comparing `file_size` + `file_mtime` against the live file's metadata.
+-- A REFRESH on any row pointing at this image, or a file that changed out
+-- from under us, invalidates the cached row.
+--
+-- `scan_complete = 0` rows exist *during* the scan so the UI can read
+-- partial data; they flip to `1` on successful finish. A crash mid-scan
+-- leaves the row at `0`, which the next scan attempt overwrites without
+-- trusting partial data.
+
+CREATE TABLE image_scans (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  image_path          TEXT    NOT NULL UNIQUE,
+  -- Freshness key: combined with image_path, this is what tells us whether
+  -- the cached scan still describes the file we're about to read.
+  file_size           INTEGER NOT NULL,
+  file_mtime          INTEGER NOT NULL,
+  scanned_at          INTEGER NOT NULL,
+  scan_complete       INTEGER NOT NULL DEFAULT 0,
+  -- Decoder chain output: innermost-to-outermost JSON array (e.g. ["xz","raw"]).
+  format_chain        TEXT,
+  -- True decompressed size from the scan; distinct from the optimistic
+  -- xz-footer estimate stored in burn_jobs.image_bytes.
+  uncompressed_bytes  INTEGER,
+  -- SHA-256 of the decoded source bytes, captured during the same pass.
+  -- Allows the burn pipeline to skip its own source-hash computation when
+  -- the cached scan covers the bytes about to be written.
+  image_sha256        TEXT,
+  validation_result   TEXT,
+  validation_detail   TEXT,
+  -- JSON blob: PartitionSummary or null. Per-partition `filesystem` fields
+  -- carry the labels picked up from superblock samples during the scan.
+  partition_table     TEXT,
+  -- JSON array of BootSource values. Empty array = no boot signals.
+  boot_sources        TEXT    NOT NULL DEFAULT '[]',
+  -- JSON map: { partition_index_str: compressed_byte_offset_int }. Lets the
+  -- future partition-extraction feature jump straight to a partition's
+  -- bytes without rescanning the chain.
+  partition_offsets   TEXT    NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX idx_image_scans_path ON image_scans(image_path);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -20,6 +20,7 @@ use crate::db::{self, Db};
 use crate::forensic::{self, HostInfo};
 use crate::image::{BootSource, DiskImage};
 use crate::inspect::PartitionSummary;
+use crate::joblog::JobLogger;
 use crate::snapshot::{self, RestoreResult, SnapshotResult, DEFAULT_SNAPSHOT_BYTES};
 
 /// Probe an image source for partition table + per-partition
@@ -52,9 +53,19 @@ pub fn inspect_image_partitions(
     path: String,
 ) -> Result<(), String> {
     std::thread::spawn(move || {
-        let summary = DiskImage::open(Path::new(&path))
+        let log = crate::joblog::db_logger_for(&app, &job_id);
+        log.debug("scan: partition probe starting");
+        let summary = DiskImage::open_with_log(Path::new(&path), &log)
             .ok()
             .and_then(|img| img.partitions().cloned());
+        match &summary {
+            Some(s) => log.info(&format!(
+                "scan: partition probe found {} partition(s), table = {}",
+                s.partitions.len(),
+                s.table_kind
+            )),
+            None => log.info("scan: partition probe found no recognised table"),
+        }
         #[derive(serde::Serialize, Clone)]
         struct Payload {
             job_id: String,
@@ -77,10 +88,21 @@ pub fn inspect_image_partitions(
 #[tauri::command]
 pub fn inspect_image_bootable(app: AppHandle, job_id: String, path: String) -> Result<(), String> {
     std::thread::spawn(move || {
-        let (bootable, sources) = match DiskImage::open(Path::new(&path)) {
+        let log = crate::joblog::db_logger_for(&app, &job_id);
+        log.debug("scan: bootability probe starting");
+        let (bootable, sources) = match DiskImage::open_with_log(Path::new(&path), &log) {
             Ok(img) => (img.is_bootable(), img.boot_sources().to_vec()),
-            Err(_) => (false, Vec::new()),
+            Err(e) => {
+                log.warn(&format!(
+                    "scan: bootability probe could not open image: {e}"
+                ));
+                (false, Vec::new())
+            }
         };
+        log.info(&format!(
+            "scan: bootability probe: bootable={bootable}, sources={}",
+            sources.len()
+        ));
         #[derive(serde::Serialize, Clone)]
         struct Payload {
             job_id: String,
@@ -96,6 +118,23 @@ pub fn inspect_image_bootable(app: AppHandle, job_id: String, path: String) -> R
             },
         );
     });
+    Ok(())
+}
+
+/// Trigger a deep scan for an image attached to a queue row. Spawns a
+/// worker thread that streams through the decoder chain, captures
+/// per-partition filesystem samples, and emits progressive Tauri events
+/// so the row UI can populate as data arrives. Cached results live in
+/// `image_scans` keyed by `image_path`; subsequent calls with the same
+/// path short-circuit to `image-scan-complete` if the cached row is
+/// still fresh (file size + mtime unchanged).
+#[tauri::command]
+pub fn scan_image_for_row(
+    app: AppHandle,
+    job_id: String,
+    image_path: String,
+) -> Result<(), String> {
+    crate::image_scan::spawn_scan(app, job_id, image_path);
     Ok(())
 }
 

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -26,7 +26,13 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 //
 // Each entry: (label, sql). The sql must be a single statement that either
 // errors or returns a row matching the expected predicate in `run_health`.
-const REQUIRED_TABLES: &[&str] = &["config", "burn_jobs", "burn_logs", "schema_migrations"];
+const REQUIRED_TABLES: &[&str] = &[
+    "config",
+    "burn_jobs",
+    "burn_logs",
+    "image_scans",
+    "schema_migrations",
+];
 
 fn now_ms() -> i64 {
     std::time::SystemTime::now()

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -63,6 +63,28 @@ pub struct BurnLogRow {
     pub message: String,
 }
 
+/// Cached deep-scan results for a disk image. Lookup key is `image_path`;
+/// `file_size` + `file_mtime` are the freshness check (read returns None
+/// when they don't match the live file). All JSON-typed fields are stored
+/// as strings the frontend deserialises.
+#[derive(Serialize, Clone)]
+pub struct ImageScanRow {
+    pub id: i64,
+    pub image_path: String,
+    pub file_size: i64,
+    pub file_mtime: i64,
+    pub scanned_at: i64,
+    pub scan_complete: bool,
+    pub format_chain: Option<String>,
+    pub uncompressed_bytes: Option<i64>,
+    pub image_sha256: Option<String>,
+    pub validation_result: Option<String>,
+    pub validation_detail: Option<String>,
+    pub partition_table: Option<String>,
+    pub boot_sources: String,
+    pub partition_offsets: String,
+}
+
 fn now_ms() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -276,6 +298,194 @@ pub fn record_burn_failed(db: &Db, job_id: &str, code: &str, message: &str) {
         "INSERT INTO burn_logs (burn_id, ts, level, message) VALUES (?1, ?2, 'error', ?3)",
         params![id, now_ms(), format!("{code}: {message}")],
     );
+}
+
+// ----------------------------------------------------------------------------
+// image_scans cache. Keyed by image_path; freshness is verified on read via
+// file_size + file_mtime. Helpers below all take `&Db` directly so scan
+// workers (which run on `std::thread::spawn` and don't hold a Tauri State)
+// can call them through the captured AppHandle.
+// ----------------------------------------------------------------------------
+
+const IMAGE_SCAN_COLS: &str = "id, image_path, file_size, file_mtime, scanned_at,
+    scan_complete, format_chain, uncompressed_bytes, image_sha256,
+    validation_result, validation_detail, partition_table, boot_sources,
+    partition_offsets";
+
+fn map_image_scan_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<ImageScanRow> {
+    Ok(ImageScanRow {
+        id: r.get(0)?,
+        image_path: r.get(1)?,
+        file_size: r.get(2)?,
+        file_mtime: r.get(3)?,
+        scanned_at: r.get(4)?,
+        scan_complete: r.get::<_, i64>(5)? != 0,
+        format_chain: r.get(6)?,
+        uncompressed_bytes: r.get(7)?,
+        image_sha256: r.get(8)?,
+        validation_result: r.get(9)?,
+        validation_detail: r.get(10)?,
+        partition_table: r.get(11)?,
+        boot_sources: r.get(12)?,
+        partition_offsets: r.get(13)?,
+    })
+}
+
+/// Look up the cached scan for an image path. Returns `None` if no row
+/// exists. Returns `Some(row)` regardless of whether the cached `file_size`
+/// + `file_mtime` still match the live file — callers do their own
+/// freshness check via `image_scan_is_fresh` so a stale row isn't silently
+/// discarded (the partition probe might still be useful for a quick view
+/// even when the file has been touched).
+pub fn image_scan_get(db: &Db, image_path: &str) -> Option<ImageScanRow> {
+    let conn = db.0.lock().ok()?;
+    let sql = format!("SELECT {IMAGE_SCAN_COLS} FROM image_scans WHERE image_path = ?1");
+    conn.query_row(&sql, params![image_path], map_image_scan_row)
+        .ok()
+}
+
+/// True when the cached scan's `file_size` + `file_mtime` still match the
+/// live file on disk. Used by callers to decide whether to short-circuit
+/// a fresh scan.
+pub fn image_scan_is_fresh(row: &ImageScanRow) -> bool {
+    let Ok(meta) = std::fs::metadata(&row.image_path) else {
+        return false;
+    };
+    let size = meta.len() as i64;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    size == row.file_size && mtime == row.file_mtime
+}
+
+/// Mark a scan as in-progress for `image_path`. Overwrites any stale row.
+/// Called at the start of a scan so the UI can read partial data via the
+/// progress events while the worker continues.
+#[allow(clippy::too_many_arguments)]
+pub fn image_scan_begin(db: &Db, image_path: &str, file_size: i64, file_mtime: i64) -> Option<i64> {
+    let conn = db.0.lock().ok()?;
+    conn.execute(
+        "INSERT INTO image_scans (image_path, file_size, file_mtime, scanned_at,
+            scan_complete, boot_sources, partition_offsets)
+         VALUES (?1, ?2, ?3, ?4, 0, '[]', '{}')
+         ON CONFLICT(image_path) DO UPDATE SET
+            file_size = excluded.file_size,
+            file_mtime = excluded.file_mtime,
+            scanned_at = excluded.scanned_at,
+            scan_complete = 0,
+            format_chain = NULL,
+            uncompressed_bytes = NULL,
+            image_sha256 = NULL,
+            validation_result = NULL,
+            validation_detail = NULL,
+            partition_table = NULL,
+            boot_sources = '[]',
+            partition_offsets = '{}'",
+        params![image_path, file_size, file_mtime, now_ms()],
+    )
+    .ok()?;
+    Some(conn.last_insert_rowid())
+}
+
+/// Patch the cached scan with a partial update. Each `Option` field is
+/// applied only when `Some(...)` — call sites can land one field at a
+/// time as the scan worker discovers it. Always updates `scanned_at` so
+/// freshness reflects the most recent write.
+#[derive(Default, Debug, Clone)]
+pub struct ImageScanPatch {
+    pub format_chain: Option<String>,
+    pub uncompressed_bytes: Option<i64>,
+    pub image_sha256: Option<String>,
+    pub validation_result: Option<String>,
+    pub validation_detail: Option<String>,
+    pub partition_table: Option<String>,
+    pub boot_sources: Option<String>,
+    pub partition_offsets: Option<String>,
+    pub scan_complete: Option<bool>,
+}
+
+pub fn image_scan_patch(db: &Db, image_path: &str, patch: ImageScanPatch) {
+    let Ok(conn) = db.0.lock() else { return };
+    let mut sets: Vec<String> = Vec::new();
+    let mut vals: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(v) = patch.format_chain {
+        sets.push(format!("format_chain = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.uncompressed_bytes {
+        sets.push(format!("uncompressed_bytes = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.image_sha256 {
+        sets.push(format!("image_sha256 = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.validation_result {
+        sets.push(format!("validation_result = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.validation_detail {
+        sets.push(format!("validation_detail = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.partition_table {
+        sets.push(format!("partition_table = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.boot_sources {
+        sets.push(format!("boot_sources = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.partition_offsets {
+        sets.push(format!("partition_offsets = ?{}", sets.len() + 1));
+        vals.push(Box::new(v));
+    }
+    if let Some(v) = patch.scan_complete {
+        sets.push(format!("scan_complete = ?{}", sets.len() + 1));
+        vals.push(Box::new(v as i64));
+    }
+    sets.push(format!("scanned_at = ?{}", sets.len() + 1));
+    vals.push(Box::new(now_ms()));
+    if sets.is_empty() {
+        return;
+    }
+    let sql = format!(
+        "UPDATE image_scans SET {} WHERE image_path = ?{}",
+        sets.join(", "),
+        sets.len() + 1
+    );
+    vals.push(Box::new(image_path.to_string()));
+    let params_dyn: Vec<&dyn rusqlite::ToSql> = vals.iter().map(|b| b.as_ref()).collect();
+    let _ = conn.execute(&sql, params_dyn.as_slice());
+}
+
+/// Delete any cached scan row for `image_path`. Used by the frontend's
+/// REFRESH action so a re-expand triggers a fresh scan.
+pub fn image_scan_invalidate(db: &Db, image_path: &str) {
+    let Ok(conn) = db.0.lock() else { return };
+    let _ = conn.execute(
+        "DELETE FROM image_scans WHERE image_path = ?1",
+        params![image_path],
+    );
+}
+
+#[tauri::command]
+pub fn image_scan_lookup(db: State<'_, Db>, image_path: String) -> Option<ImageScanRow> {
+    let row = image_scan_get(&db, &image_path)?;
+    if image_scan_is_fresh(&row) {
+        Some(row)
+    } else {
+        None
+    }
+}
+
+#[tauri::command]
+pub fn image_scan_clear(db: State<'_, Db>, image_path: String) -> Result<(), String> {
+    image_scan_invalidate(&db, &image_path);
+    Ok(())
 }
 
 #[allow(dead_code)]

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -332,11 +332,11 @@ fn map_image_scan_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<ImageScanRow> {
 }
 
 /// Look up the cached scan for an image path. Returns `None` if no row
-/// exists. Returns `Some(row)` regardless of whether the cached `file_size`
-/// + `file_mtime` still match the live file — callers do their own
-/// freshness check via `image_scan_is_fresh` so a stale row isn't silently
-/// discarded (the partition probe might still be useful for a quick view
-/// even when the file has been touched).
+/// exists. Returns `Some(row)` regardless of whether the cached
+/// `file_size` and `file_mtime` still match the live file — callers do
+/// their own freshness check via `image_scan_is_fresh` so a stale row
+/// isn't silently discarded (the partition probe might still be useful
+/// for a quick view even when the file has been touched).
 pub fn image_scan_get(db: &Db, image_path: &str) -> Option<ImageScanRow> {
     let conn = db.0.lock().ok()?;
     let sql = format!("SELECT {IMAGE_SCAN_COLS} FROM image_scans WHERE image_path = ?1");

--- a/src-tauri/src/decoder_chain/disk_reader.rs
+++ b/src-tauri/src/decoder_chain/disk_reader.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::path::Path;
 
 use crate::inspect::{inspect_block_read, PartitionSummary};
+use crate::joblog::{JobLogger, NullLogger};
 
 use super::block_view::{slurp_prefix, PrefixBlockView, DEFAULT_PREFIX_BYTES};
 use super::identify::identify_data_stream;
@@ -34,9 +35,35 @@ impl DiskReader {
     /// Walks the registered formats once per layer until the source
     /// is raw bytes. `format_chain()` afterwards reports the labels
     /// seen, innermost first, always terminating in `"raw"`.
+    ///
+    /// No per-item logging — see `open_with_log` for the burn path.
     pub fn open(path: &Path) -> io::Result<Self> {
+        Self::open_with_log(path, &NullLogger)
+    }
+
+    /// Open `path` and resolve its decoder chain, emitting debug/info
+    /// entries into the per-item log via `log`.
+    pub fn open_with_log(path: &Path, log: &dyn JobLogger) -> io::Result<Self> {
+        log.debug(&format!("decoder_chain: opening {}", path.display()));
+        if log.debug_enabled() {
+            // Cheap independent peek of the first 16 bytes for diagnostic
+            // hex display — useful for "why didn't it match xz?" forensics.
+            // Done before we hand the file to RawFilehandle so the chain's
+            // own peek-and-rewind stays untouched.
+            use std::io::Read;
+            let mut head = [0u8; 16];
+            if let Ok(mut f) = std::fs::File::open(path) {
+                let n = f.read(&mut head).unwrap_or(0);
+                let hex: String = head[..n]
+                    .iter()
+                    .map(|b| format!("{:02x}", b))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                log.debug(&format!("decoder_chain: head[0..{n}] = {hex}"));
+            }
+        }
         let leaf: Box<dyn ReaderInterface> = Box::new(RawFilehandle::open(path)?);
-        let (chain, labels) = identify_data_stream(leaf, READERS)?;
+        let (chain, labels) = identify_data_stream(leaf, READERS, log)?;
         Ok(Self { chain, labels })
     }
 
@@ -48,7 +75,7 @@ impl DiskReader {
         src: Box<dyn ReaderInterface>,
         registry: &[&'static dyn super::format::FormatTryOpen],
     ) -> io::Result<Self> {
-        let (chain, labels) = identify_data_stream(src, registry)?;
+        let (chain, labels) = identify_data_stream(src, registry, &NullLogger)?;
         Ok(Self { chain, labels })
     }
 

--- a/src-tauri/src/decoder_chain/formats/bzip2.rs
+++ b/src-tauri/src/decoder_chain/formats/bzip2.rs
@@ -169,7 +169,8 @@ mod tests {
 
         let leaf: Box<dyn ReaderInterface> = Box::new(RawFilehandle::open(&p).unwrap());
         let registry: &[&'static dyn FormatTryOpen] = &[&BZIP2_FORMAT];
-        let (mut chain, labels) = identify_data_stream(leaf, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(leaf, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["bzip2", "raw"]);
         let drained = drain(&mut *chain);
         assert_eq!(drained, payload);

--- a/src-tauri/src/decoder_chain/formats/gzip.rs
+++ b/src-tauri/src/decoder_chain/formats/gzip.rs
@@ -156,7 +156,8 @@ mod tests {
 
         let leaf: Box<dyn ReaderInterface> = Box::new(RawFilehandle::open(&p).unwrap());
         let registry: &[&'static dyn FormatTryOpen] = &[&GZIP_FORMAT];
-        let (mut chain, labels) = identify_data_stream(leaf, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(leaf, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["gzip", "raw"]);
         assert_eq!(drain(&mut *chain), payload);
     }

--- a/src-tauri/src/decoder_chain/formats/xz.rs
+++ b/src-tauri/src/decoder_chain/formats/xz.rs
@@ -158,7 +158,8 @@ mod tests {
         let leaf = RawFilehandle::open(&p).unwrap();
         let src: Box<dyn ReaderInterface> = Box::new(leaf);
         let registry: &[&'static dyn FormatTryOpen] = &[&XZ_FORMAT];
-        let (mut chain, labels) = identify_data_stream(src, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(src, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["xz", "raw"]);
         assert_eq!(drain(&mut *chain), payload);
     }

--- a/src-tauri/src/decoder_chain/formats/zstd.rs
+++ b/src-tauri/src/decoder_chain/formats/zstd.rs
@@ -173,7 +173,8 @@ mod tests {
 
         let leaf: Box<dyn ReaderInterface> = Box::new(RawFilehandle::open(&p).unwrap());
         let registry: &[&'static dyn FormatTryOpen] = &[&ZSTD_FORMAT];
-        let (mut chain, labels) = identify_data_stream(leaf, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(leaf, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["zstd", "raw"]);
         assert_eq!(drain(&mut *chain), payload);
     }

--- a/src-tauri/src/decoder_chain/identify.rs
+++ b/src-tauri/src/decoder_chain/identify.rs
@@ -16,6 +16,7 @@
 
 use super::format::FormatTryOpen;
 use super::interface::ReaderInterface;
+use crate::joblog::JobLogger;
 use std::io;
 
 /// Safety cap on chain depth. 16 is generous: real-world stacks are
@@ -29,23 +30,46 @@ const MAX_DEPTH: usize = 16;
 /// `labels[0]` is the outermost format that matched, `labels[last]`
 /// is always `"raw"` — appended unconditionally so callers can rely
 /// on a non-empty chain ending in the raw-bytes producer.
+///
+/// `log` receives one debug entry per layer attempt and one info entry
+/// summarising the final chain. Pass `&NullLogger` for probe/inspect
+/// callers not attached to a queue item.
 pub fn identify_data_stream(
     mut src: Box<dyn ReaderInterface>,
     registry: &[&'static dyn FormatTryOpen],
+    log: &dyn JobLogger,
 ) -> io::Result<(Box<dyn ReaderInterface>, Vec<&'static str>)> {
     let mut labels: Vec<&'static str> = Vec::new();
-    for _ in 0..MAX_DEPTH {
-        match try_one_round(src, registry) {
+    for depth in 0..MAX_DEPTH {
+        if log.debug_enabled() {
+            log.debug(&format!(
+                "decoder_chain: identify depth={depth} trying {n} formats",
+                n = registry.len()
+            ));
+        }
+        match try_one_round(src, registry, log) {
             Ok((wrapped, label)) => {
+                if log.debug_enabled() {
+                    log.debug(&format!("decoder_chain: matched layer {depth} = {label}"));
+                }
                 labels.push(label);
                 src = wrapped;
             }
             Err(unchanged) => {
+                if log.debug_enabled() {
+                    log.debug(&format!(
+                        "decoder_chain: no format claimed depth={depth}, terminating at raw"
+                    ));
+                }
                 labels.push("raw");
+                log.info(&format!("decoder_chain: {}", labels.join(" → ")));
                 return Ok((unchanged, labels));
             }
         }
     }
+    log.error(&format!(
+        "decoder_chain: exceeded MAX_DEPTH ({MAX_DEPTH}) — possible recursive format bomb"
+    ));
     Err(io::Error::new(
         io::ErrorKind::InvalidData,
         format!("decoder chain exceeded MAX_DEPTH ({MAX_DEPTH}) — possible recursive format bomb"),
@@ -62,11 +86,18 @@ type RoundResult = Result<(Box<dyn ReaderInterface>, &'static str), Box<dyn Read
 fn try_one_round(
     mut src: Box<dyn ReaderInterface>,
     registry: &[&'static dyn FormatTryOpen],
+    log: &dyn JobLogger,
 ) -> RoundResult {
     for fmt in registry {
         match fmt.try_open(src) {
             Ok(wrapped) => return Ok((wrapped, fmt.label())),
             Err(returned) => {
+                if log.debug_enabled() {
+                    log.debug(&format!(
+                        "decoder_chain: format {label} declined",
+                        label = fmt.label()
+                    ));
+                }
                 src = returned;
             }
         }

--- a/src-tauri/src/decoder_chain/mod.rs
+++ b/src-tauri/src/decoder_chain/mod.rs
@@ -153,6 +153,90 @@ mod tests {
         out
     }
 
+    /// In-test logger that records every entry so assertions can see what
+    /// the chain reported. Mirrors the `RecordingLogger` in joblog's own
+    /// test module — that one isn't reachable from here, so we keep a
+    /// small copy for chain-level diagnostics.
+    struct DiagRecorder {
+        entries: std::sync::Mutex<Vec<(crate::joblog::LogLevel, String)>>,
+    }
+    impl DiagRecorder {
+        fn new() -> Self {
+            Self {
+                entries: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+        fn lines(&self) -> Vec<String> {
+            self.entries
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(lv, m)| format!("[{}] {m}", lv.as_str()))
+                .collect()
+        }
+    }
+    impl crate::joblog::JobLogger for DiagRecorder {
+        fn log(&self, level: crate::joblog::LogLevel, message: &str) {
+            self.entries
+                .lock()
+                .unwrap()
+                .push((level, message.to_string()));
+        }
+        fn debug_enabled(&self) -> bool {
+            true
+        }
+    }
+
+    /// End-to-end shape check for `.img.xz`: exactly the case the user is
+    /// asking about. Builds a real xz-compressed payload, opens it through
+    /// `DiskReader::open_with_log`, and asserts the chain reports the
+    /// expected two-link result (`xz → raw`) — no phantom "img" layer,
+    /// because `.img` is a filename convention, not a format.
+    #[test]
+    fn img_xz_chain_yields_xz_then_raw_with_expected_log_lines() {
+        use std::io::Write;
+        use xz2::write::XzEncoder;
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("payload.img.xz");
+        let payload: Vec<u8> = (0..4_096u32).map(|i| (i % 251) as u8).collect();
+        let mut e = XzEncoder::new(Vec::new(), 1);
+        e.write_all(&payload).unwrap();
+        std::fs::write(&p, e.finish().unwrap()).unwrap();
+
+        let rec = DiagRecorder::new();
+        let mut dr = DiskReader::open_with_log(&p, &rec).expect("open_with_log");
+        assert_eq!(dr.format_chain(), vec!["xz", "raw"]);
+
+        // Drain to prove decompression works end-to-end.
+        let mut out = Vec::new();
+        let mut buf = [0u8; 128];
+        loop {
+            match dr.read(&mut buf).unwrap() {
+                0 => break,
+                n => out.extend_from_slice(&buf[..n]),
+            }
+        }
+        assert_eq!(out, payload);
+
+        // Verify the log trail surfaces every link the user expects to
+        // see. Substring matching keeps the test resilient to wording.
+        let lines = rec.lines();
+        let dump = lines.join("\n");
+        let must_have = [
+            "opening",
+            "head[0..",
+            "matched layer 0 = xz",
+            "no format claimed depth=1, terminating at raw",
+            "xz → raw",
+        ];
+        for needle in must_have {
+            assert!(
+                lines.iter().any(|l| l.contains(needle)),
+                "expected a log line containing {needle:?}, got:\n{dump}"
+            );
+        }
+    }
+
     #[test]
     fn raw_filehandle_reads_bytes_from_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -179,7 +263,8 @@ mod tests {
         let body: Vec<u8> = (10u8..50).collect();
         let src: Box<dyn ReaderInterface> = Box::new(MemReader::new(body.clone()));
         let registry: &[&'static dyn FormatTryOpen] = &[];
-        let (mut chain, labels) = identify_data_stream(src, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(src, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["raw"]);
         assert_eq!(drain(&mut *chain), body);
     }
@@ -199,7 +284,8 @@ mod tests {
         body.extend_from_slice(b"hello world");
         let src: Box<dyn ReaderInterface> = Box::new(MemReader::new(body.clone()));
         let registry: &[&'static dyn FormatTryOpen] = &[&FAKE_A];
-        let (mut chain, labels) = identify_data_stream(src, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(src, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["fakeA", "raw"]);
         assert_eq!(drain(&mut *chain), b"hello world");
     }
@@ -210,7 +296,8 @@ mod tests {
         body.extend_from_slice(b"payload");
         let src: Box<dyn ReaderInterface> = Box::new(MemReader::new(body.clone()));
         let registry: &[&'static dyn FormatTryOpen] = &[&FAKE_A, &FAKE_B];
-        let (mut chain, labels) = identify_data_stream(src, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(src, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["fakeB", "fakeA", "raw"]);
         assert_eq!(drain(&mut *chain), b"payload");
     }
@@ -220,7 +307,8 @@ mod tests {
         let body = vec![0xCCu8, 1, 2, 3, 4];
         let src: Box<dyn ReaderInterface> = Box::new(MemReader::new(body.clone()));
         let registry: &[&'static dyn FormatTryOpen] = &[&FAKE_A, &FAKE_B];
-        let (mut chain, labels) = identify_data_stream(src, registry).unwrap();
+        let (mut chain, labels) =
+            identify_data_stream(src, registry, &crate::joblog::NullLogger).unwrap();
         assert_eq!(labels, vec!["raw"]);
         assert_eq!(drain(&mut *chain), body);
     }

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -842,6 +842,9 @@ fn spawn_elevated_burn_inner(
     let skip_verify = read_config("verify.skip")
         .map(|v| v == "true")
         .unwrap_or(false);
+    let debug_logging = read_config("debug.logging")
+        .map(|v| v == "true")
+        .unwrap_or(false);
 
     let helper_cmd = build_helper_command(
         &exe.to_string_lossy(),
@@ -854,6 +857,7 @@ fn spawn_elevated_burn_inner(
         workers_count,
         queue_depth,
         skip_verify,
+        debug_logging,
     );
     let prompt = "Disk Cutter needs administrator access to write the disk image directly to the device you selected.";
     let script = build_osascript_script(&helper_cmd, prompt);
@@ -915,6 +919,7 @@ fn build_helper_command(
     workers: Option<usize>,
     queue_depth: Option<usize>,
     skip_verify: bool,
+    debug_logging: bool,
 ) -> String {
     let mut cmd = format!(
         "'{}' --helper-burn --image='{}' --target='{}' --job='{}' --progress='{}'",
@@ -938,6 +943,9 @@ fn build_helper_command(
     }
     if skip_verify {
         cmd.push_str(" --skip-verify=true");
+    }
+    if debug_logging {
+        cmd.push_str(" --debug=true");
     }
     cmd
 }
@@ -1027,6 +1035,7 @@ enum HelperEvent {
     Progress(JobUpdate),
     Complete(JobComplete),
     Failure(JobFailure),
+    Log { level: String, message: String },
 }
 
 fn parse_helper_line(job_id: &str, line: &str) -> Option<HelperEvent> {
@@ -1108,6 +1117,19 @@ fn parse_helper_line(job_id: &str, line: &str) -> Option<HelperEvent> {
                 .unwrap_or("")
                 .to_string(),
         })),
+        "log" => {
+            let level = val
+                .get("level")
+                .and_then(|v| v.as_str())
+                .unwrap_or("info")
+                .to_string();
+            let message = val
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(HelperEvent::Log { level, message })
+        }
         _ => None,
     }
 }
@@ -1144,6 +1166,10 @@ fn emit_helper_line(app: &AppHandle, job_id: &str, line: &str) -> Option<&'stati
             app.state::<ActiveBurns>().remove(&failure.job_id);
             let _ = app.emit("disk-cutter://job-error", failure);
             Some("error")
+        }
+        HelperEvent::Log { level, message } => {
+            db::append_log(&app.state::<Db>(), job_id, &level, &message);
+            Some("log")
         }
     }
 }
@@ -1271,7 +1297,11 @@ fn run_job(
     let image = Path::new(image_path);
     let target = Path::new(target_device);
 
-    let (mut reader, info) = source::open_streaming(image)
+    // Snapshot the debug toggle at burn start so toggling mid-run doesn't
+    // half-apply.
+    let job_log = crate::joblog::db_logger_for(app, job_id);
+
+    let (mut reader, info) = source::open_streaming_with_log(image, &job_log)
         .map_err(|e| fail(job_id, "EUNSUPPORTED", &format!("open image: {e}")))?;
     let total_bytes = info.uncompressed_bytes;
 
@@ -1303,7 +1333,7 @@ fn run_job(
     )
     .map_err(|e| fail_for_burn_error(job_id, &e))?;
 
-    let (mut reader2, _) = source::open_streaming(image)
+    let (mut reader2, _) = source::open_streaming_with_log(image, &job_log)
         .map_err(|e| fail(job_id, "EIMAGE", &format!("reopen image: {e}")))?;
     let mut device_reader = device_io
         .open_read(target)
@@ -1991,6 +2021,35 @@ mod tests {
     }
 
     #[test]
+    fn parse_helper_line_log_yields_log_event() {
+        let line =
+            r#"{"kind":"log","level":"debug","message":"decoder_chain: matched layer 0 = xz"}"#;
+        let ev = parse_helper_line("j", line).expect("parsed");
+        match ev {
+            HelperEvent::Log { level, message } => {
+                assert_eq!(level, "debug");
+                assert_eq!(message, "decoder_chain: matched layer 0 = xz");
+            }
+            _ => panic!("expected Log"),
+        }
+    }
+
+    #[test]
+    fn parse_helper_line_log_defaults_missing_fields() {
+        // Robustness: a malformed helper line shouldn't kill the tail
+        // thread. Missing level defaults to info, missing message to "".
+        let line = r#"{"kind":"log"}"#;
+        let ev = parse_helper_line("j", line).expect("parsed");
+        match ev {
+            HelperEvent::Log { level, message } => {
+                assert_eq!(level, "info");
+                assert_eq!(message, "");
+            }
+            _ => panic!("expected Log"),
+        }
+    }
+
+    #[test]
     fn parse_helper_line_error_passes_code_and_message_through() {
         let line = r#"{"kind":"error","error_code":"EIO","error_message":"disk gone"}"#;
         let ev = parse_helper_line("j", line).unwrap();
@@ -2016,6 +2075,7 @@ mod tests {
             None,
             None,
             false,
+            false,
         );
         assert_eq!(
             s,
@@ -2039,6 +2099,7 @@ mod tests {
             None,
             None,
             false,
+            false,
         );
         assert!(s.contains("--image='/tmp/it'\\''s a test.iso'"), "got {s}");
     }
@@ -2056,12 +2117,14 @@ mod tests {
             Some(8),
             Some(31),
             true,
+            true,
         );
         assert!(s.contains("--writer='pipelined'"), "got {s}");
         assert!(s.contains("--chunk-bytes=2097152"), "got {s}");
         assert!(s.contains("--workers=8"), "got {s}");
         assert!(s.contains("--queue-depth=31"), "got {s}");
         assert!(s.contains("--skip-verify=true"), "got {s}");
+        assert!(s.contains("--debug=true"), "got {s}");
     }
 
     #[test]
@@ -2077,11 +2140,13 @@ mod tests {
             None,
             None,
             false,
+            false,
         );
         assert!(!s.contains("--chunk-bytes="), "got {s}");
         assert!(!s.contains("--workers="), "got {s}");
         assert!(!s.contains("--queue-depth="), "got {s}");
         assert!(!s.contains("--skip-verify="), "got {s}");
+        assert!(!s.contains("--debug="), "got {s}");
     }
 
     #[test]

--- a/src-tauri/src/helper.rs
+++ b/src-tauri/src/helper.rs
@@ -2,12 +2,13 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use serde::Serialize;
 
 use crate::hash::HashAlgo;
+use crate::joblog::{JobLogger, LogLevel};
 use crate::pipeline::{self, BurnError, VerifyMismatch};
 use crate::source;
 #[cfg(unix)]
@@ -37,6 +38,53 @@ enum HelperMessage {
         error_code: String,
         error_message: String,
     },
+    /// Per-job log entry. The parent's `tail_helper` parses these and
+    /// forwards them into the `burn_logs` row for the matching job_id,
+    /// so the per-item log captures decoder-chain / pipeline diagnostics
+    /// alongside the lifecycle events the parent writes directly.
+    Log { level: String, message: String },
+}
+
+/// Logger that emits `HelperMessage::Log` lines into the shared progress
+/// JSONL the parent tails. `debug_enabled` is taken from the helper's
+/// `--debug=` CLI arg (the parent reads the user's `debug.logging` pref
+/// at spawn time and passes it through). When off, `debug()` is a no-op
+/// — no JSONL line written, no string formatting cost incurred by
+/// debug_enabled()-guarded call sites.
+pub(crate) struct HelperLogger {
+    writer: Arc<Mutex<BufWriter<File>>>,
+    debug_enabled: bool,
+}
+
+impl HelperLogger {
+    fn new(writer: Arc<Mutex<BufWriter<File>>>, debug_enabled: bool) -> Self {
+        Self {
+            writer,
+            debug_enabled,
+        }
+    }
+}
+
+impl JobLogger for HelperLogger {
+    fn log(&self, level: LogLevel, message: &str) {
+        if level == LogLevel::Debug && !self.debug_enabled {
+            return;
+        }
+        let msg = HelperMessage::Log {
+            level: level.as_str().to_string(),
+            message: message.to_string(),
+        };
+        if let Ok(mut w) = self.writer.lock() {
+            if let Ok(s) = serde_json::to_string(&msg) {
+                let _ = writeln!(w, "{}", s);
+                let _ = w.flush();
+            }
+        }
+    }
+
+    fn debug_enabled(&self) -> bool {
+        self.debug_enabled
+    }
 }
 
 pub fn run_helper(args: &[String]) -> i32 {
@@ -75,6 +123,9 @@ pub fn run_helper(args: &[String]) -> i32 {
     let skip_verify: bool = arg_value(args, "--skip-verify=")
         .map(|v| v == "true")
         .unwrap_or(false);
+    let debug_enabled: bool = arg_value(args, "--debug=")
+        .map(|v| v == "true")
+        .unwrap_or(false);
     // TODO: once disks.rs is no longer hot, propagate config `hash.algo` via
     // spawn_elevated_burn's helper command line. Until then the helper defaults
     // to SHA-256 regardless of UI pref.
@@ -87,7 +138,7 @@ pub fn run_helper(args: &[String]) -> i32 {
         Ok(f) => f,
         Err(_) => return 2,
     };
-    let writer = std::sync::Mutex::new(BufWriter::new(file));
+    let writer = Arc::new(Mutex::new(BufWriter::new(file)));
     let emit = |msg: &HelperMessage| {
         if let Ok(mut w) = writer.lock() {
             if let Ok(s) = serde_json::to_string(msg) {
@@ -96,22 +147,29 @@ pub fn run_helper(args: &[String]) -> i32 {
             }
         }
     };
+    let job_log = HelperLogger::new(Arc::clone(&writer), debug_enabled);
+    if debug_enabled {
+        job_log.debug(&format!(
+            "helper: starting burn image={image} target={target} chunk={chunk_size} workers={workers} qdepth={queue_depth}"
+        ));
+    }
 
-    let (mut reader, source_info) = match source::open_streaming(Path::new(&image)) {
-        Ok(v) => v,
-        Err(e) => {
-            let code = if e.kind() == std::io::ErrorKind::InvalidInput {
-                "EUNSUPPORTED"
-            } else {
-                "EIMAGE"
-            };
-            emit(&HelperMessage::Error {
-                error_code: code.into(),
-                error_message: format!("open image: {e}"),
-            });
-            return 1;
-        }
-    };
+    let (mut reader, source_info) =
+        match source::open_streaming_with_log(Path::new(&image), &job_log) {
+            Ok(v) => v,
+            Err(e) => {
+                let code = if e.kind() == std::io::ErrorKind::InvalidInput {
+                    "EUNSUPPORTED"
+                } else {
+                    "EIMAGE"
+                };
+                emit(&HelperMessage::Error {
+                    error_code: code.into(),
+                    error_message: format!("open image: {e}"),
+                });
+                return 1;
+            }
+        };
     let image_total_bytes = source_info.uncompressed_bytes;
 
     let device_io: Box<dyn DeviceIo> =
@@ -279,7 +337,8 @@ pub fn run_helper(args: &[String]) -> i32 {
     // Hash mismatch — fall back to the slow byte-compare path to collect
     // per-sector forensic detail (LBA/offset/expected/actual).
     drop(dev_reader);
-    let (mut reader2, _) = match source::open_streaming(Path::new(&image)) {
+    job_log.info("helper: hash mismatch, reopening image for byte-compare diff");
+    let (mut reader2, _) = match source::open_streaming_with_log(Path::new(&image), &job_log) {
         Ok(v) => v,
         Err(e) => {
             emit(&HelperMessage::Error {

--- a/src-tauri/src/image.rs
+++ b/src-tauri/src/image.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 
 use crate::decoder_chain::DiskReader;
 use crate::inspect::{make_part_info, table_kind_label, PartitionSummary};
-use crate::validate::{classify_buffer, ValidationReport, SNIFF_WINDOW_BYTES};
+use crate::validate::{ValidationReport, SNIFF_WINDOW_BYTES};
 
 /// The container-format family of an image file. Used internally to
 /// pick the right reader and to surface a stable string for the UI.
@@ -150,37 +150,87 @@ impl DiskImage {
     /// reader is opened (or, for compressed sources, the prefix is
     /// decompressed) inside this call so subsequent question-asking is
     /// constant-time.
+    ///
+    /// No per-item logging — see `open_with_log` for the scan path.
     pub fn open(path: &Path) -> Result<Self, ImageError> {
+        Self::open_with_log(path, &crate::joblog::NullLogger)
+    }
+
+    /// Same as `open`, but emits debug entries into the per-item log via
+    /// `log`. Use this from scan-time commands (validate / inspect
+    /// partitions / inspect bootable) so the row's log captures format
+    /// identification, container metadata, and (for compressed inputs)
+    /// the decoder chain layers.
+    pub fn open_with_log(
+        path: &Path,
+        log: &dyn crate::joblog::JobLogger,
+    ) -> Result<Self, ImageError> {
+        log.debug(&format!("scan: opening image {}", path.display()));
+        if let Ok(meta) = std::fs::metadata(path) {
+            log.debug(&format!("scan: file size = {} bytes", meta.len()));
+        }
         let ext = path
             .extension()
             .and_then(|s| s.to_str())
             .map(|s| s.to_ascii_lowercase());
+        log.debug(&format!(
+            "scan: extension = {}",
+            ext.as_deref().unwrap_or("(none)")
+        ));
         let (format, backend) = match ext.as_deref() {
             Some("qcow2") | Some("qcow") => {
                 let r = qcow2::Qcow2Reader::open(path).map_err(std::io::Error::other)?;
+                log.debug(&format!(
+                    "scan: qcow2 v{} cluster={} bytes virtual_size={} bytes",
+                    r.version(),
+                    r.cluster_size(),
+                    r.virtual_size()
+                ));
                 (ImageFormat::Qcow2, Backend::Block(Box::new(r)))
             }
             Some("vhd") => {
                 let r = vhd::VhdReader::open(path).map_err(std::io::Error::other)?;
+                log.debug(&format!(
+                    "scan: vhd virtual_size={} bytes",
+                    r.virtual_size()
+                ));
                 (ImageFormat::Vhd, Backend::Block(Box::new(r)))
             }
             Some("vhdx") => {
                 let r = vhdx::VhdxReader::open(path).map_err(std::io::Error::other)?;
+                log.debug(&format!(
+                    "scan: vhdx virtual_size={} bytes",
+                    r.virtual_size()
+                ));
                 (ImageFormat::Vhdx, Backend::Block(Box::new(r)))
             }
             Some("vmdk") => {
                 let r = vmdk::VmdkReader::open(path).map_err(std::io::Error::other)?;
+                log.debug(&format!(
+                    "scan: vmdk virtual_size={} bytes",
+                    r.virtual_size()
+                ));
                 (ImageFormat::Vmdk, Backend::Block(Box::new(r)))
             }
-            Some("gz") => (ImageFormat::CompressedGz, decompressed_prefix(path)?),
-            Some("xz") => (ImageFormat::CompressedXz, decompressed_prefix(path)?),
-            Some("bz2") | Some("bzip2") => (ImageFormat::CompressedBz2, decompressed_prefix(path)?),
-            Some("zst") | Some("zstd") => (ImageFormat::CompressedZst, decompressed_prefix(path)?),
+            Some("gz") => (ImageFormat::CompressedGz, decompressed_prefix(path, log)?),
+            Some("xz") => (ImageFormat::CompressedXz, decompressed_prefix(path, log)?),
+            Some("bz2") | Some("bzip2") => {
+                (ImageFormat::CompressedBz2, decompressed_prefix(path, log)?)
+            }
+            Some("zst") | Some("zstd") => {
+                (ImageFormat::CompressedZst, decompressed_prefix(path, log)?)
+            }
             _ => {
                 let r = FileDevice::open(path).map_err(std::io::Error::other)?;
+                log.debug(&format!(
+                    "scan: raw image size_bytes={} ({} sectors @ 512B)",
+                    r.size_bytes(),
+                    r.size_bytes() / 512
+                ));
                 (ImageFormat::Raw, Backend::Block(Box::new(r)))
             }
         };
+        log.info(&format!("scan: format identified as {:?}", format));
         Ok(Self {
             path: path.to_path_buf(),
             format,
@@ -208,27 +258,36 @@ impl DiskImage {
         }
     }
 
-    /// Partition + filesystem summary. `None` for compressed sources or
-    /// images with no recognised table.
+    /// Partition + filesystem summary. `None` for images with no recognised
+    /// table. For compressed sources the probe runs over the slurped prefix
+    /// via `PrefixBlockView` — partitions whose start LBA is inside the
+    /// prefix get full filesystem detail; entries that point past the
+    /// prefix still appear in the table, just with `filesystem: None`.
     pub fn partitions(&self) -> Option<&PartitionSummary> {
         self.partitions
             .get_or_init(|| match &self.backend {
                 Backend::Block(dev) => summarise(dev.as_ref()).ok(),
-                Backend::Compressed { .. } => None,
+                Backend::Compressed { prefix } => {
+                    let view =
+                        crate::decoder_chain::block_view::PrefixBlockView::new(prefix.clone());
+                    summarise(&view).ok()
+                }
             })
             .as_ref()
     }
 
     /// Every boot signal this image presents. Empty = not bootable by
     /// any of the mechanisms we recognise. See [`BootSource`] for the
-    /// individual cases.
+    /// individual cases. For compressed sources the probe runs over the
+    /// slurped prefix — most boot signals (MBR boot code, GPT EFI System
+    /// Partition, El Torito at 0x8800) sit inside the default prefix size.
     pub fn boot_sources(&self) -> &[BootSource] {
         self.boot_sources.get_or_init(|| match &self.backend {
             Backend::Block(dev) => compute_boot_sources(dev.as_ref(), self.partitions()),
-            // Compressed sources: we could in principle look for the
-            // ISO 9660 boot record inside the prefix, but the offset
-            // (0x8800) is past most realistic prefix windows. Skip.
-            Backend::Compressed { .. } => Vec::new(),
+            Backend::Compressed { prefix } => {
+                let view = crate::decoder_chain::block_view::PrefixBlockView::new(prefix.clone());
+                compute_boot_sources(&view, self.partitions())
+            }
         })
     }
 
@@ -244,12 +303,14 @@ impl DiskImage {
         match &self.backend {
             Backend::Block(dev) => crate::validate::validate_block(dev.as_ref()),
             Backend::Compressed { prefix } => {
-                // Same fall-through as the original validate_compressed:
-                // if the prefix classifies cleanly we accept it; if not,
-                // we don't want the literal "boot sector / unrecognised"
-                // hint a raw classify would return, because the user
-                // can't action that for a compressed source.
-                match classify_buffer(prefix) {
+                // Run the same partition-table-first / filesystem-sniff
+                // logic as the Block path, just over the decompressed
+                // prefix. Falls back to the softer "not a recognised
+                // disk image" message when nothing matches so the UI
+                // doesn't surface the partition-probe's internal hints
+                // (which the user can't action on a compressed source).
+                let view = crate::decoder_chain::block_view::PrefixBlockView::new(prefix.clone());
+                match crate::validate::validate_block(&view) {
                     v @ ValidationReport::Valid { .. } => v,
                     ValidationReport::Invalid { .. } => ValidationReport::Invalid {
                         reason: "compressed contents are not a recognised disk image".into(),
@@ -264,9 +325,16 @@ impl DiskImage {
 /// prefix. Mirrors what `validate::validate_compressed` used to do —
 /// the byte count is `SNIFF_WINDOW_BYTES_INSPECT` (0x8200) so all
 /// FAT/NTFS/exFAT/ext/HFS+/ISO 9660 signatures are reachable.
-fn decompressed_prefix(path: &Path) -> Result<Backend, ImageError> {
-    let mut reader =
-        DiskReader::open(path).map_err(|e| ImageError::Io(std::io::Error::other(e)))?;
+fn decompressed_prefix(
+    path: &Path,
+    log: &dyn crate::joblog::JobLogger,
+) -> Result<Backend, ImageError> {
+    let mut reader = DiskReader::open_with_log(path, log)
+        .map_err(|e| ImageError::Io(std::io::Error::other(e)))?;
+    log.debug(&format!(
+        "scan: decompressing first {} bytes of prefix for fs sniff",
+        SNIFF_WINDOW_BYTES
+    ));
     let mut buf = vec![0u8; SNIFF_WINDOW_BYTES];
     let mut filled = 0usize;
     while filled < buf.len() {
@@ -277,6 +345,7 @@ fn decompressed_prefix(path: &Path) -> Result<Backend, ImageError> {
         }
     }
     buf.truncate(filled);
+    log.debug(&format!("scan: decompressed prefix = {} bytes", buf.len()));
     Ok(Backend::Compressed { prefix: buf })
 }
 
@@ -309,7 +378,10 @@ fn summarise(dev: &dyn BlockRead) -> partitions::Result<PartitionSummary> {
 /// boolean. We list partition-level signals first (more specific) and
 /// then fall back to disk-level (less specific). El Torito is checked
 /// separately because it lives outside the partition-table world.
-fn compute_boot_sources(dev: &dyn BlockRead, parts: Option<&PartitionSummary>) -> Vec<BootSource> {
+pub(crate) fn compute_boot_sources(
+    dev: &dyn BlockRead,
+    parts: Option<&PartitionSummary>,
+) -> Vec<BootSource> {
     let mut out = Vec::new();
 
     // Per-partition signals. The active/attribute/type-GUID values
@@ -518,7 +590,93 @@ mod tests {
         let img = DiskImage::open(&p).unwrap();
         assert_eq!(img.format(), ImageFormat::CompressedGz);
         assert!(matches!(img.validate(), ValidationReport::Valid { .. }));
-        // Compressed sources skip boot probes.
-        assert!(img.boot_sources().is_empty());
+        // The FAT32 OEM string at offset 0x52 lives inside the MBR boot
+        // code region, so has_mbr_bootloader fires — that's the correct
+        // probe result for a real FAT32 boot sector, surfaced through
+        // the prefix view.
+        assert!(img.boot_sources().contains(&BootSource::MbrBootloader));
+    }
+
+    /// Build a minimal MBR image with one Linux partition, compress it
+    /// four different ways, and verify each `DiskImage` surfaces the
+    /// partition table through the per-format decoder chain → prefix
+    /// view → partition probe pipeline.
+    ///
+    /// Regression coverage for the bug where `Backend::Compressed`
+    /// short-circuited `partitions()` / `boot_sources()` to `None` /
+    /// empty regardless of what the prefix actually contained.
+    #[test]
+    fn compressed_formats_surface_partition_table_through_prefix_view() {
+        use std::io::Write;
+        let dir = tempdir().unwrap();
+
+        let mut image = vec![0u8; 32 * 1024];
+        let entry = 0x1BE;
+        image[entry] = 0x80; // active
+        image[entry + 4] = 0x83; // Linux
+        image[entry + 8..entry + 12].copy_from_slice(&2048u32.to_le_bytes());
+        image[entry + 12..entry + 16].copy_from_slice(&8u32.to_le_bytes());
+        image[510] = 0x55;
+        image[511] = 0xAA;
+
+        let gz_bytes = {
+            use flate2::write::GzEncoder;
+            use flate2::Compression;
+            let mut e = GzEncoder::new(Vec::new(), Compression::default());
+            e.write_all(&image).unwrap();
+            e.finish().unwrap()
+        };
+        let xz_bytes = {
+            use xz2::write::XzEncoder;
+            let mut e = XzEncoder::new(Vec::new(), 1);
+            e.write_all(&image).unwrap();
+            e.finish().unwrap()
+        };
+        let bz2_bytes = {
+            use bzip2::write::BzEncoder;
+            let mut e = BzEncoder::new(Vec::new(), bzip2::Compression::default());
+            e.write_all(&image).unwrap();
+            e.finish().unwrap()
+        };
+        let zst_bytes = zstd::encode_all(&image[..], 0).unwrap();
+
+        let cases: [(&str, &[u8], ImageFormat); 4] = [
+            ("disk.img.gz", &gz_bytes, ImageFormat::CompressedGz),
+            ("disk.img.xz", &xz_bytes, ImageFormat::CompressedXz),
+            ("disk.img.bz2", &bz2_bytes, ImageFormat::CompressedBz2),
+            ("disk.img.zst", &zst_bytes, ImageFormat::CompressedZst),
+        ];
+
+        for (name, body, expected_format) in cases {
+            let p = dir.path().join(name);
+            std::fs::write(&p, body).unwrap();
+            let img = DiskImage::open(&p).unwrap_or_else(|e| panic!("open {name}: {e}"));
+            assert_eq!(img.format(), expected_format, "format for {name}");
+
+            let parts = img
+                .partitions()
+                .unwrap_or_else(|| panic!("{name}: partitions() returned None"));
+            assert_eq!(parts.table_kind, "MBR", "{name}: table kind");
+            assert_eq!(parts.partitions.len(), 1, "{name}: partition count");
+            assert_eq!(
+                parts.partitions[0].kind_label, "Linux filesystem",
+                "{name}: partition type"
+            );
+
+            assert!(
+                matches!(img.validate(), ValidationReport::Valid { .. }),
+                "{name}: validate should report Valid"
+            );
+
+            // The partition is flagged active in the MBR, so the boot
+            // probe should surface `MbrActive { index: 1 }`.
+            let sources = img.boot_sources();
+            assert!(
+                sources
+                    .iter()
+                    .any(|s| matches!(s, BootSource::MbrActive { index: 1 })),
+                "{name}: expected MbrActive boot source, got {sources:?}"
+            );
+        }
     }
 }

--- a/src-tauri/src/image_scan.rs
+++ b/src-tauri/src/image_scan.rs
@@ -1,0 +1,387 @@
+//! Deep image scanner.
+//!
+//! Single sequential pass through a disk image (raw or compressed via the
+//! decoder chain) that yields:
+//!
+//! - Format chain labels ("xz → raw", etc.)
+//! - Partition table from the prefix (MBR / GPT layout)
+//! - Per-partition filesystem labels, picked up from 64 KB superblock samples
+//!   captured as the stream flows past each partition's start LBA
+//! - Boot signals visible within the prefix
+//! - True uncompressed size *for xz only* (parsed from the stream footer);
+//!   gzip / bzip2 / zstd fall back to the on-disk file size as a placeholder
+//!
+//! Stops at `max(partition_start) + 64 KB` so multi-GB compressed images
+//! don't pay for decompressing the whole stream when all the user wants is
+//! filesystem labels. The trailing portion (which would have given us
+//! source SHA-256 and the true uncompressed size for non-xz formats) is
+//! deliberately skipped — see `docs/status.md` for the deferred-work
+//! revisit notes.
+//!
+//! Results are upserted into the `image_scans` cache table keyed by image
+//! path. Progressive Tauri events fire so the UI populates fields one at
+//! a time as they become known.
+
+use std::path::Path;
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::db::{self, Db, ImageScanPatch};
+use crate::decoder_chain::block_view::PrefixBlockView;
+use crate::decoder_chain::DiskReader;
+use crate::joblog::JobLogger;
+
+/// Bytes of post-table sample we keep for each partition. Big enough for
+/// ext2/3/4 superblock at offset 1024, NTFS BPB at 0, FAT BPB at 0, HFS+
+/// volume header at 1024, plus headroom for anything padded.
+const PER_PARTITION_SAMPLE_BYTES: usize = 64 * 1024;
+
+/// How much of the leading stream we slurp into a `BlockRead`-friendly
+/// buffer for the initial partition / boot probes. Mirrors the
+/// `DEFAULT_PREFIX_BYTES` used inside the decoder_chain.
+const PREFIX_BYTES: usize = 4 * 1024 * 1024;
+
+/// How often progress events fire during the discard-and-sample walk.
+const PROGRESS_THROTTLE_MS: u64 = 150;
+
+#[derive(Serialize, Clone)]
+struct ProgressPayload {
+    job_id: String,
+    image_path: String,
+    bytes_done: u64,
+    bytes_total: u64,
+}
+
+#[derive(Serialize, Clone)]
+struct PartitionFsPayload {
+    job_id: String,
+    image_path: String,
+    partition_index: u32,
+    filesystem: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct CompletePayload {
+    job_id: String,
+    image_path: String,
+}
+
+/// Sparse `BlockRead` view assembled from the prefix slurp + per-partition
+/// samples. Reads inside any captured range succeed; everywhere else returns
+/// `OutOfBounds`. Lets `partitions::sniff` work against the same byte ranges
+/// the partition probe would have seen on a fully random-access source.
+struct SparseSampleView {
+    ranges: Vec<(u64, Vec<u8>)>,
+    end: u64,
+}
+
+impl SparseSampleView {
+    fn new(ranges: Vec<(u64, Vec<u8>)>) -> Self {
+        let end = ranges
+            .iter()
+            .map(|(o, b)| o + b.len() as u64)
+            .max()
+            .unwrap_or(0);
+        Self { ranges, end }
+    }
+}
+
+impl fs_core::BlockRead for SparseSampleView {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> fs_core::Result<()> {
+        let len = buf.len() as u64;
+        for (sample_start, sample_bytes) in &self.ranges {
+            let sample_end = sample_start + sample_bytes.len() as u64;
+            if offset >= *sample_start && offset + len <= sample_end {
+                let rel = (offset - sample_start) as usize;
+                buf.copy_from_slice(&sample_bytes[rel..rel + buf.len()]);
+                return Ok(());
+            }
+        }
+        Err(fs_core::Error::OutOfBounds {
+            offset,
+            len,
+            size: self.end,
+        })
+    }
+    fn size_bytes(&self) -> u64 {
+        self.end
+    }
+}
+
+/// Spawn a deep-scan worker for `image_path` against the row `job_id`.
+/// Idempotent: if a fresh cache row exists, fires an immediate
+/// `image-scan-complete` and returns. Otherwise upserts an in-progress
+/// row, runs the scan, and updates the row in-place as it discovers each
+/// piece.
+pub fn spawn_scan(app: AppHandle, job_id: String, image_path: String) {
+    std::thread::spawn(move || {
+        if let Some(row) = db::image_scan_get(&app.state::<Db>(), &image_path) {
+            if row.scan_complete && db::image_scan_is_fresh(&row) {
+                emit_complete(&app, &job_id, &image_path);
+                return;
+            }
+        }
+        if let Err(e) = run_scan(&app, &job_id, &image_path) {
+            eprintln!("image_scan: failed for {image_path}: {e}");
+        }
+        emit_complete(&app, &job_id, &image_path);
+    });
+}
+
+fn emit_complete(app: &AppHandle, job_id: &str, image_path: &str) {
+    let _ = app.emit(
+        "disk-cutter://image-scan-complete",
+        CompletePayload {
+            job_id: job_id.to_string(),
+            image_path: image_path.to_string(),
+        },
+    );
+}
+
+fn run_scan(app: &AppHandle, job_id: &str, image_path: &str) -> Result<(), String> {
+    let path = Path::new(image_path);
+    let meta = std::fs::metadata(path).map_err(|e| format!("stat {image_path}: {e}"))?;
+    let file_size = meta.len() as i64;
+    let file_mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    let db_state = app.state::<Db>();
+    db::image_scan_begin(&db_state, image_path, file_size, file_mtime);
+
+    let log = crate::joblog::db_logger_for(app, job_id);
+    log.info(&format!("scan: starting deep scan of {image_path}"));
+
+    // Open the chain and grab the prefix in one shot. Captures format_chain
+    // and the partition table from the same bytes.
+    let mut reader =
+        DiskReader::open_with_log(path, &log).map_err(|e| format!("open decoder chain: {e}"))?;
+    let format_chain = reader.format_chain().to_vec();
+    let format_chain_json =
+        serde_json::to_string(&format_chain).unwrap_or_else(|_| "[]".to_string());
+
+    let prefix = reader
+        .slurp_prefix(PREFIX_BYTES)
+        .map_err(|e| format!("slurp prefix: {e}"))?;
+    let prefix_view = PrefixBlockView::new(prefix.clone());
+    let summary = crate::inspect::inspect_block_read(&prefix_view);
+    let partition_table_json = summary
+        .as_ref()
+        .map(|s| serde_json::to_string(s).unwrap_or_else(|_| "null".to_string()));
+    let boot_sources = crate::image::compute_boot_sources(&prefix_view, summary.as_ref());
+    let boot_sources_json =
+        serde_json::to_string(&boot_sources).unwrap_or_else(|_| "[]".to_string());
+
+    // True uncompressed size — only xz exposes this without a full pass.
+    // For all other compressed formats and for raw we fall back to the
+    // on-disk file size as a conservative placeholder.
+    let uncompressed_bytes = if matches!(format_chain.first().copied(), Some("xz")) {
+        crate::xz_footer::read_total_uncompressed(path).map(|v| v as i64)
+    } else {
+        Some(file_size)
+    };
+
+    db::image_scan_patch(
+        &db_state,
+        image_path,
+        ImageScanPatch {
+            format_chain: Some(format_chain_json),
+            uncompressed_bytes,
+            partition_table: partition_table_json.clone(),
+            boot_sources: Some(boot_sources_json),
+            ..Default::default()
+        },
+    );
+
+    // If no partition table or no partitions, the scan is effectively done
+    // — there's nothing past the prefix the user is going to see.
+    let Some(mut summary) = summary else {
+        log.info("scan: no partition table; stopping at prefix");
+        db::image_scan_patch(
+            &db_state,
+            image_path,
+            ImageScanPatch {
+                scan_complete: Some(true),
+                ..Default::default()
+            },
+        );
+        return Ok(());
+    };
+    if summary.partitions.is_empty() {
+        db::image_scan_patch(
+            &db_state,
+            image_path,
+            ImageScanPatch {
+                scan_complete: Some(true),
+                ..Default::default()
+            },
+        );
+        return Ok(());
+    }
+
+    // Compute sample ranges (start_byte, want_bytes) per partition.
+    // Skip partitions whose start is *inside* the prefix — we already
+    // have their bytes in the prefix view and the sniff at the bottom
+    // will use that.
+    let mut sample_ranges: Vec<(u32, u64, usize)> = Vec::new();
+    let mut stop_at: u64 = prefix.len() as u64;
+    for p in &summary.partitions {
+        let want = PER_PARTITION_SAMPLE_BYTES.min(p.length_bytes as usize);
+        let end = p.start_bytes + want as u64;
+        if end > stop_at {
+            stop_at = end;
+        }
+        if p.start_bytes >= prefix.len() as u64 {
+            sample_ranges.push((p.index, p.start_bytes, want));
+        }
+    }
+
+    log.info(&format!(
+        "scan: walking chain to stop_at={stop_at} bytes, collecting {} per-partition sample(s)",
+        sample_ranges.len()
+    ));
+
+    // Walk the chain. Position = uncompressed bytes already consumed
+    // (including the prefix slurp). Read in chunks; copy into per-partition
+    // sample buffers when the cursor overlaps a target range; discard
+    // bytes that fall outside any range.
+    let bytes_total = uncompressed_bytes.map(|v| v as u64).unwrap_or(stop_at);
+    let mut pos: u64 = prefix.len() as u64;
+    let mut samples: Vec<(u32, u64, Vec<u8>)> = sample_ranges
+        .iter()
+        .map(|(idx, start, want)| (*idx, *start, Vec::with_capacity(*want)))
+        .collect();
+
+    let mut chunk = vec![0u8; 256 * 1024];
+    let mut last_progress = std::time::Instant::now();
+
+    while pos < stop_at {
+        // Cap the chunk so we don't overshoot stop_at.
+        let want = ((stop_at - pos) as usize).min(chunk.len());
+        let n = reader
+            .read(&mut chunk[..want])
+            .map_err(|e| format!("read chain: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        let chunk_start = pos;
+        let chunk_end = pos + n as u64;
+
+        for (_, target_start, buf) in samples.iter_mut() {
+            let target_end = *target_start + buf.capacity() as u64;
+            // Overlap of [chunk_start, chunk_end) with [target_start, target_end)
+            let lo = chunk_start.max(*target_start);
+            let hi = chunk_end.min(target_end);
+            if lo < hi {
+                let chunk_off = (lo - chunk_start) as usize;
+                let len = (hi - lo) as usize;
+                buf.extend_from_slice(&chunk[chunk_off..chunk_off + len]);
+            }
+        }
+
+        pos = chunk_end;
+
+        if last_progress.elapsed() >= Duration::from_millis(PROGRESS_THROTTLE_MS) {
+            let _ = app.emit(
+                "disk-cutter://image-scan-progress",
+                ProgressPayload {
+                    job_id: job_id.to_string(),
+                    image_path: image_path.to_string(),
+                    bytes_done: pos,
+                    bytes_total,
+                },
+            );
+            last_progress = std::time::Instant::now();
+        }
+    }
+
+    let _ = app.emit(
+        "disk-cutter://image-scan-progress",
+        ProgressPayload {
+            job_id: job_id.to_string(),
+            image_path: image_path.to_string(),
+            bytes_done: pos,
+            bytes_total,
+        },
+    );
+
+    // Assemble the sparse view: prefix + each filled sample.
+    let mut ranges: Vec<(u64, Vec<u8>)> = Vec::new();
+    ranges.push((0, prefix));
+    for (idx, start, buf) in &samples {
+        if !buf.is_empty() {
+            ranges.push((*start, buf.clone()));
+            log.debug(&format!(
+                "scan: partition {idx} sample collected: {} bytes at offset {start}",
+                buf.len()
+            ));
+        }
+    }
+    let view = SparseSampleView::new(ranges);
+
+    // Re-run sniff for each partition using the assembled view; this
+    // populates the per-partition filesystem label that was None in the
+    // prefix-only summary.
+    let parts_raw = match partitions::probe::probe(&view) {
+        Ok((_, parts)) => parts,
+        Err(_) => Vec::new(),
+    };
+    for (idx, p) in parts_raw.iter().enumerate() {
+        let fs = partitions::sniff::sniff(&view, p).ok();
+        let fs_label: Option<String> = fs.map(crate::inspect::format_fs_kind);
+        let partition_index = (idx + 1) as u32;
+        if let Some(part_info) = summary
+            .partitions
+            .iter_mut()
+            .find(|p| p.index == partition_index)
+        {
+            part_info.filesystem = fs_label.clone();
+        }
+        let _ = app.emit(
+            "disk-cutter://image-scan-partition-fs",
+            PartitionFsPayload {
+                job_id: job_id.to_string(),
+                image_path: image_path.to_string(),
+                partition_index,
+                filesystem: fs_label,
+            },
+        );
+    }
+
+    let final_partition_json = serde_json::to_string(&summary).unwrap_or_else(|_| "null".into());
+    db::image_scan_patch(
+        &db_state,
+        image_path,
+        ImageScanPatch {
+            partition_table: Some(final_partition_json),
+            scan_complete: Some(true),
+            ..Default::default()
+        },
+    );
+    log.info("scan: deep scan complete");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fs_core::BlockRead;
+
+    #[test]
+    fn sparse_view_reads_within_a_range_and_errors_outside() {
+        let view = SparseSampleView::new(vec![(0, vec![1, 2, 3, 4]), (100, vec![10, 20, 30])]);
+        let mut buf = [0u8; 2];
+        view.read_at(0, &mut buf).unwrap();
+        assert_eq!(buf, [1, 2]);
+        view.read_at(101, &mut buf).unwrap();
+        assert_eq!(buf, [20, 30]);
+        let mut over = [0u8; 2];
+        // Spans a gap — should error.
+        assert!(view.read_at(3, &mut over).is_err());
+    }
+}

--- a/src-tauri/src/joblog.rs
+++ b/src-tauri/src/joblog.rs
@@ -1,0 +1,247 @@
+//! Per-job structured logger.
+//!
+//! Every action tied to a queue item — decoder-chain probes, burn lifecycle,
+//! verify mismatches — writes log lines into that item's `burn_logs` row in
+//! the DB. Clicking the job in the queue surfaces the log inline, so the
+//! forensic record sits next to the data instead of being hunted out of a
+//! global stream.
+//!
+//! Levels mirror the standard log crates (debug / info / warn / error).
+//! `debug` is gated by the `debug.logging` preference; when off it's a
+//! cheap no-op (no string formatting cost if the caller uses the
+//! `log.debug_enabled()` guard before constructing a message).
+//!
+//! Two implementations:
+//! - `DbJobLogger` — used by the parent process for in-process burns and
+//!   for parent-side dispatch of helper-emitted log lines.
+//! - `NullLogger` — drops everything; for code paths not tied to a job
+//!   (probe/inspect/CLI).
+//!
+//! Helper subprocess uses its own implementation (in `helper.rs`) that
+//! emits log lines as JSONL `HelperMessage::Log` records the parent's
+//! `tail_helper` thread parses and forwards to `DbJobLogger`.
+
+use tauri::{AppHandle, Manager};
+
+use crate::db::{self, Db};
+
+/// Look up the user's `debug.logging` preference. Returns false if the DB
+/// isn't managed (early-startup paths) or the key is unset.
+pub fn debug_logging_enabled(app: &AppHandle) -> bool {
+    let Some(db) = app.try_state::<Db>() else {
+        return false;
+    };
+    let Ok(conn) = db.0.lock() else {
+        return false;
+    };
+    conn.query_row(
+        "SELECT value FROM config WHERE key = 'debug.logging'",
+        [],
+        |r| r.get::<_, String>(0),
+    )
+    .map(|v| v == "true")
+    .unwrap_or(false)
+}
+
+/// Build a `DbJobLogger` for `job_id` with the current debug-logging pref
+/// snapshot. Use this at the entry point of any scan/burn worker so the
+/// pref value is captured once for the duration of the work (no mid-scan
+/// toggling).
+pub fn db_logger_for(app: &AppHandle, job_id: &str) -> DbJobLogger {
+    DbJobLogger::new(app.clone(), job_id.to_string(), debug_logging_enabled(app))
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "debug" => Self::Debug,
+            "warn" => Self::Warn,
+            "error" => Self::Error,
+            _ => Self::Info,
+        }
+    }
+}
+
+pub trait JobLogger: Send + Sync {
+    fn log(&self, level: LogLevel, message: &str);
+
+    /// Returns whether `debug` will actually be recorded. Callers building
+    /// expensive debug messages should guard with this to avoid the format
+    /// cost when the user has the toggle off.
+    fn debug_enabled(&self) -> bool {
+        true
+    }
+
+    fn debug(&self, message: &str) {
+        if self.debug_enabled() {
+            self.log(LogLevel::Debug, message);
+        }
+    }
+    fn info(&self, message: &str) {
+        self.log(LogLevel::Info, message);
+    }
+    fn warn(&self, message: &str) {
+        self.log(LogLevel::Warn, message);
+    }
+    fn error(&self, message: &str) {
+        self.log(LogLevel::Error, message);
+    }
+}
+
+/// Drops every log call. For probe / inspect paths that aren't attached to a
+/// queue item — there is no `burn_logs` row to write to, and emitting to
+/// stderr would just produce noise nobody reads.
+pub struct NullLogger;
+
+impl JobLogger for NullLogger {
+    fn log(&self, _: LogLevel, _: &str) {}
+    fn debug_enabled(&self) -> bool {
+        false
+    }
+}
+
+/// Writes log lines into the `burn_logs` row for `job_id` via the parent
+/// app's `Db` state. Cloned across the burn thread by capturing the
+/// `AppHandle`; the `Db` is resolved per log call (cheap HashMap lookup,
+/// no need to outlive the spawning function).
+///
+/// `debug_enabled` is snapshot at construction so toggling the pref
+/// mid-burn doesn't half-apply (matches the existing burn_params
+/// snapshot pattern).
+pub struct DbJobLogger {
+    app: AppHandle,
+    job_id: String,
+    debug_enabled: bool,
+}
+
+impl DbJobLogger {
+    pub fn new(app: AppHandle, job_id: String, debug_enabled: bool) -> Self {
+        Self {
+            app,
+            job_id,
+            debug_enabled,
+        }
+    }
+}
+
+impl JobLogger for DbJobLogger {
+    fn log(&self, level: LogLevel, message: &str) {
+        if level == LogLevel::Debug && !self.debug_enabled {
+            return;
+        }
+        if let Some(db) = self.app.try_state::<Db>() {
+            db::append_log(&db, &self.job_id, level.as_str(), message);
+        }
+    }
+
+    fn debug_enabled(&self) -> bool {
+        self.debug_enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    /// Test logger that records every call for assertion.
+    pub struct RecordingLogger {
+        pub entries: StdMutex<Vec<(LogLevel, String)>>,
+        pub debug_enabled: bool,
+    }
+
+    impl RecordingLogger {
+        pub fn new(debug_enabled: bool) -> Self {
+            Self {
+                entries: StdMutex::new(Vec::new()),
+                debug_enabled,
+            }
+        }
+        pub fn entries(&self) -> Vec<(LogLevel, String)> {
+            self.entries.lock().unwrap().clone()
+        }
+    }
+
+    impl JobLogger for RecordingLogger {
+        fn log(&self, level: LogLevel, message: &str) {
+            if level == LogLevel::Debug && !self.debug_enabled {
+                return;
+            }
+            self.entries
+                .lock()
+                .unwrap()
+                .push((level, message.to_string()));
+        }
+        fn debug_enabled(&self) -> bool {
+            self.debug_enabled
+        }
+    }
+
+    #[test]
+    fn null_logger_drops_everything() {
+        let l = NullLogger;
+        l.debug("d");
+        l.info("i");
+        l.warn("w");
+        l.error("e");
+        assert!(!l.debug_enabled());
+    }
+
+    #[test]
+    fn level_round_trips_through_strings() {
+        for lvl in [
+            LogLevel::Debug,
+            LogLevel::Info,
+            LogLevel::Warn,
+            LogLevel::Error,
+        ] {
+            assert_eq!(LogLevel::parse(lvl.as_str()), lvl);
+        }
+    }
+
+    #[test]
+    fn level_from_str_falls_back_to_info_for_unknown() {
+        assert_eq!(LogLevel::parse("nope"), LogLevel::Info);
+        assert_eq!(LogLevel::parse(""), LogLevel::Info);
+    }
+
+    #[test]
+    fn recording_logger_with_debug_off_drops_debug_keeps_others() {
+        let l = RecordingLogger::new(false);
+        l.debug("d");
+        l.info("i");
+        l.warn("w");
+        l.error("e");
+        let levels: Vec<LogLevel> = l.entries().iter().map(|(lv, _)| *lv).collect();
+        assert_eq!(
+            levels,
+            vec![LogLevel::Info, LogLevel::Warn, LogLevel::Error]
+        );
+    }
+
+    #[test]
+    fn recording_logger_with_debug_on_keeps_debug() {
+        let l = RecordingLogger::new(true);
+        l.debug("d");
+        l.info("i");
+        let levels: Vec<LogLevel> = l.entries().iter().map(|(lv, _)| *lv).collect();
+        assert_eq!(levels, vec![LogLevel::Debug, LogLevel::Info]);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,9 @@ pub mod forensic;
 pub mod hash;
 mod helper;
 pub mod image;
+pub mod image_scan;
 pub mod inspect;
+pub mod joblog;
 pub mod pipeline;
 pub mod qemu;
 pub mod readers;
@@ -29,7 +31,8 @@ pub use helper::run_helper;
 
 use db::{
     burn_jobs_active, burn_jobs_clear, burn_jobs_list, burn_logs_for_job, burn_logs_list,
-    config_all, config_get, config_set, enqueue_burn, remove_burn_job, set_burn_target, Db,
+    config_all, config_get, config_set, enqueue_burn, image_scan_clear, image_scan_lookup,
+    remove_burn_job, set_burn_target, Db,
 };
 use disks::{
     abort_and_quit, app_info, cancel_write, check_fda, find_orphan_helpers, has_active_burns,
@@ -95,9 +98,12 @@ pub fn run() {
             set_burn_target,
             burn_logs_list,
             burn_logs_for_job,
+            image_scan_lookup,
+            image_scan_clear,
             commands::inspect_partitions,
             commands::inspect_image_partitions,
             commands::inspect_image_bootable,
+            commands::scan_image_for_row,
             commands::capture_snapshot,
             commands::restore_snapshot,
             commands::export_burn_report,

--- a/src-tauri/src/source.rs
+++ b/src-tauri/src/source.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 use fs_core::BlockReadStreamer;
 
 use crate::decoder_chain::DiskReader;
+use crate::joblog::{JobLogger, NullLogger};
 use crate::readers::magic;
 
 /// Metadata about an image source that callers want before/while
@@ -87,31 +88,57 @@ pub fn probe(path: &Path) -> Option<SourceInfo> {
 /// Open a streaming reader for `path`. The returned reader yields raw
 /// disk-image bytes regardless of the underlying format; the paired
 /// `SourceInfo` tells the caller what they're dealing with for display.
+///
+/// No per-item logging — see `open_streaming_with_log` for the burn path.
 pub fn open_streaming(path: &Path) -> io::Result<(Box<dyn Read + Send>, SourceInfo)> {
+    open_streaming_with_log(path, &NullLogger)
+}
+
+/// Like `open_streaming` but emits debug/info entries into the per-item
+/// log via `log`. Used by the burn path so a row's log captures the
+/// decoder chain's behaviour for that specific image.
+pub fn open_streaming_with_log(
+    path: &Path,
+    log: &dyn JobLogger,
+) -> io::Result<(Box<dyn Read + Send>, SourceInfo)> {
     let info = probe(path)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "unsupported image format"))?;
+    log.info(&format!(
+        "source: probed {} as {} ({} bytes on disk, {} bytes uncompressed)",
+        path.display(),
+        info.format_label,
+        info.source_bytes,
+        info.uncompressed_bytes,
+    ));
     let reader: Box<dyn Read + Send> = match classify(&info.format_label) {
         Family::Qcow2 => {
+            log.debug("source: family=qcow2, routing to Qcow2Reader (random-access)");
             let r = qcow2::Qcow2Reader::open(path)
                 .map_err(|e| io::Error::other(format!("qcow2: {e:?}")))?;
             Box::new(BlockReadStreamer::new(r))
         }
         Family::Vhd => {
+            log.debug("source: family=vhd, routing to VhdReader (random-access)");
             let r =
                 vhd::VhdReader::open(path).map_err(|e| io::Error::other(format!("vhd: {e:?}")))?;
             Box::new(BlockReadStreamer::new(r))
         }
         Family::Vhdx => {
+            log.debug("source: family=vhdx, routing to VhdxReader (random-access)");
             let r = vhdx::VhdxReader::open(path)
                 .map_err(|e| io::Error::other(format!("vhdx: {e:?}")))?;
             Box::new(BlockReadStreamer::new(r))
         }
         Family::Vmdk => {
+            log.debug("source: family=vmdk, routing to VmdkReader (random-access)");
             let r = vmdk::VmdkReader::open(path)
                 .map_err(|e| io::Error::other(format!("vmdk: {e:?}")))?;
             Box::new(BlockReadStreamer::new(r))
         }
-        Family::Streaming => Box::new(DiskReader::open(path)?),
+        Family::Streaming => {
+            log.debug("source: family=streaming, routing to DiskReader (decoder chain)");
+            Box::new(DiskReader::open_with_log(path, log)?)
+        }
     };
     Ok((reader, info))
 }

--- a/src-tauri/src/validate.rs
+++ b/src-tauri/src/validate.rs
@@ -213,14 +213,28 @@ pub fn validate_image_contents(
     path: String,
 ) -> Result<(), String> {
     use crate::image::DiskImage;
+    use crate::joblog::JobLogger;
     use tauri::Emitter;
     std::thread::spawn(move || {
-        let report = match DiskImage::open(Path::new(&path)) {
+        let log = crate::joblog::db_logger_for(&app, &job_id);
+        log.info(&format!("scan: validating contents of {path}"));
+        let report = match DiskImage::open_with_log(Path::new(&path), &log) {
             Ok(img) => img.validate(),
-            Err(e) => ValidationReport::Invalid {
-                reason: e.to_string(),
-            },
+            Err(e) => {
+                log.warn(&format!("scan: could not open image for validation: {e}"));
+                ValidationReport::Invalid {
+                    reason: e.to_string(),
+                }
+            }
         };
+        match &report {
+            ValidationReport::Valid { detail } => {
+                log.info(&format!("scan: validation = VALID ({detail})"));
+            }
+            ValidationReport::Invalid { reason } => {
+                log.info(&format!("scan: validation = INVALID ({reason})"));
+            }
+        }
         #[derive(serde::Serialize, Clone)]
         struct Payload {
             job_id: String,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import {
 import { useShallow } from 'zustand/react/shallow';
 import { formatBytes } from './format.js';
 import {
-  useQueueStore, attachQueueListeners, selectJobs, selectEntries, startValidation,
+  useQueueStore, attachQueueListeners, selectJobs, selectEntries, startValidation, startScan, clearScanCache,
 } from './store/queue.js';
 import {
   computeScene, sceneToTitleKey, computeSessionStats,
@@ -316,6 +316,10 @@ function App() {
       // 'disk-cutter://image-validated' and flips job.validation; the
       // START QUEUE gate refuses to burn until it's 'valid'.
       startValidation(jobId, details.path);
+      // And the deep scan — populates per-partition filesystem labels
+      // and runs the progress bar under the row. Cached by image_path
+      // so adding the same file to N jobs only scans once.
+      startScan(jobId, details.path);
     } catch (e) {
       console.error('inspect_image failed', e);
       pushToast('error', t('error.could_not_add_image', { error: e }));
@@ -478,6 +482,38 @@ function App() {
     }
   }, [pushToast, t]);
 
+  // Re-scan an existing row's image and patch the row in place. Same Tauri
+  // call as the initial add path (inspect_image → validate → partitions +
+  // bootable), but without creating a new row or re-firing enqueue_burn.
+  // Useful when the image on disk changed, or to clear a stale validation
+  // verdict after the operator fixed something externally.
+  const refreshJob = useCallback(async (jobId) => {
+    const job = jobs.find((j) => j.id === jobId);
+    if (!job || !job.image?.path) return;
+    const path = job.image.path;
+    try {
+      const details = await invoke('inspect_image', { path });
+      const image = {
+        name: details.name,
+        path: details.path,
+        size: formatBytes(details.uncompressed_bytes),
+        bytes: details.uncompressed_bytes,
+        sectors: details.sectors,
+        format: details.format,
+        sha256: details.sha256 || '—',
+      };
+      useQueueStore.getState().refreshImage(jobId, image);
+      startValidation(jobId, details.path);
+      // REFRESH invalidates any cached deep scan for this image path so
+      // the new scan starts from scratch instead of short-circuiting.
+      await clearScanCache(details.path);
+      startScan(jobId, details.path);
+    } catch (e) {
+      console.error('refresh inspect_image failed', e);
+      pushToast('error', t('error.could_not_add_image', { error: e }));
+    }
+  }, [jobs, t, pushToast]);
+
   const retryJob = useCallback(async (jobId) => {
     // Debounce: ignore extra clicks while the previous start_write is still
     // pending. Without this, every click stacks another osascript+helper for
@@ -588,6 +624,7 @@ function App() {
     onBurn: burnJob,
     onCancelJob: cancelJob,
     onRetry: retryJob,
+    onRefreshJob: refreshJob,
     onClearDone: clearDone,
     onFlashAnother: flashAnother,
     onCopyText: copyText,
@@ -669,7 +706,7 @@ function AppBody({
   setPickerJob,
   entries, nextCopies, onChangeNextCopies, onDispatchFromEntry,
   onAdd, onAddFromUrl, onBrowseCatalog, onBurn, onCancelJob,
-  onRetry, onClearDone, onFlashAnother, onCopyText, onRemoveJob,
+  onRetry, onRefreshJob, onClearDone, onFlashAnother, onCopyText, onRemoveJob,
 }) {
   const { t } = useTranslation();
   const writingCount = jobs.filter((j) => j.state === 'writing').length;
@@ -823,6 +860,7 @@ function AppBody({
                 onCopyError={() => onCopyText(job.errorMessage || job.errorCode)}
                 onFlashAnother={() => onFlashAnother(job.id)}
                 onRetry={() => onRetry(job.id)}
+                onRefresh={() => onRefreshJob(job.id)}
                 onRemove={() => onRemoveJob(job.id)}
               />
             ))}

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -429,7 +429,7 @@ function describeBootSources(boot, t) {
 
 /* ─────────── Job Row ─────────── */
 
-function JobRow({ job, accent, expanded, onToggle, onSelectTarget, onBurn, onCancel, onRetry, onCopyHash, onCopyError, onFlashAnother, onRemove, density, fdaBlocked, confirmed }) {
+function JobRow({ job, accent, expanded, onToggle, onSelectTarget, onBurn, onCancel, onRetry, onRefresh, onCopyHash, onCopyError, onFlashAnother, onRemove, density, fdaBlocked, confirmed }) {
   const { t } = useTranslation();
   const state = job.state;
   const danger = state === 'error';
@@ -557,7 +557,34 @@ function JobRow({ job, accent, expanded, onToggle, onSelectTarget, onBurn, onCan
         boot={job.boot}
       />
 
-      {expanded && <JobDetail job={job} accent={accent} fdaBlocked={fdaBlocked} confirmed={confirmed} onCancel={onCancel} onRetry={onRetry} onCopyHash={onCopyHash} onCopyError={onCopyError} onFlashAnother={onFlashAnother} />}
+      {job.scanProgress && <ScanProgressStrip progress={job.scanProgress} accent={accent} />}
+      {expanded && <JobDetail job={job} accent={accent} fdaBlocked={fdaBlocked} confirmed={confirmed} onCancel={onCancel} onRetry={onRetry} onRefresh={onRefresh} onCopyHash={onCopyHash} onCopyError={onCopyError} onFlashAnother={onFlashAnother} />}
+    </div>
+  );
+}
+
+// Slim progress strip that sits between the row's main line and the
+// expanded detail section while the deep scan is running. Shows percent
+// when total is known, falls back to an indeterminate-style "scanning…"
+// label when the total can't be predicted (non-xz compressed sources
+// whose uncompressed size we don't recover up front).
+function ScanProgressStrip({ progress, accent }) {
+  const { t } = useTranslation();
+  const done = Number(progress.done) || 0;
+  const total = Number(progress.total) || 0;
+  const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : null;
+  return (
+    <div className="scan-strip mono small" style={{ '--accent': accent }}>
+      <span className="scan-strip-label">{t('scan.scanning', { defaultValue: 'SCANNING IMAGE' })}</span>
+      <div className="scan-strip-bar">
+        <div
+          className="scan-strip-fill"
+          style={{ width: (pct ?? 50) + '%', opacity: pct == null ? 0.5 : 1 }}
+        />
+      </div>
+      <span className="scan-strip-pct">
+        {pct != null ? `${pct}%` : '...'}
+      </span>
     </div>
   );
 }
@@ -620,7 +647,7 @@ function SuccessReadout({ job }) {
 
 /* ─────────── Job Detail (expanded drawer) ─────────── */
 
-function JobDetail({ job, accent, onCancel, onRetry, fdaBlocked, confirmed }) {
+function JobDetail({ job, accent, onCancel, onRetry, onRefresh, fdaBlocked, confirmed }) {
   const { t } = useTranslation();
   const fdaWaiting = job.errorCode === 'ENEEDS_FDA' && fdaBlocked;
   // Retry is destructive — same one-shot arm gate as Burn. Stays disabled
@@ -628,6 +655,10 @@ function JobDetail({ job, accent, onCancel, onRetry, fdaBlocked, confirmed }) {
   // is the reason this job errored). The handler in App.jsx clears confirmed
   // on click so the next destructive action needs a fresh toggle.
   const retryDisabled = !!job.retrying || fdaWaiting || !confirmed;
+  // Refresh re-scans the image and re-runs validation; non-destructive, so
+  // available in every state — except while the burn is actively reading
+  // the file, where another open could race the in-flight stream.
+  const refreshDisabled = job.state === 'writing' || job.state === 'verifying';
   return (
     <div className="job-detail">
       <div className="detail-grid">
@@ -710,6 +741,13 @@ function JobDetail({ job, accent, onCancel, onRetry, fdaBlocked, confirmed }) {
             <button className="btn btn-ghost">[ {t('detail.actions.flash_another')} ]</button>
           </>
         )}
+        <button
+          className={"btn btn-ghost" + (refreshDisabled ? " is-disabled" : "")}
+          onClick={refreshDisabled ? null : onRefresh}
+          aria-disabled={refreshDisabled || undefined}
+        >
+          [ {t('detail.actions.refresh')} ]
+        </button>
       </div>
     </div>
   );
@@ -1154,6 +1192,12 @@ const PREFS_SECTIONS = [
         ] },
     ],
   },
+  {
+    key: 'diagnostics',
+    fields: [
+      { key: 'debug.logging', type: 'toggle' },
+    ],
+  },
 ];
 
 // Keep this in sync with App.jsx — both consult the same defaults when
@@ -1173,6 +1217,7 @@ const PREFS_DEFAULTS = {
   'auto.clear_done.seconds': '0',
   'catalog.url': 'https://diskcutter.app/catalog.json',
   'catalog.refresh_hours': '24',
+  'debug.logging': 'false',
 };
 
 function prefsLabelKey(configKey) {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -190,6 +190,9 @@
     "burn_needs_arm": "Aktivieren Sie oben die Schreibwarnung, um diesen Brennvorgang scharfzuschalten.",
     "delete": "LÖSCHEN"
   },
+  "scan": {
+    "scanning": "ABBILD WIRD GESCANNT"
+  },
   "detail": {
     "block": {
       "image": "ABBILD",
@@ -221,7 +224,8 @@
       "open_log": "LOG ÖFFNEN",
       "eject": "AUSWERFEN",
       "copy_hash": "HASH KOPIEREN",
-      "flash_another": "WEITEREN SCHREIBEN"
+      "flash_another": "WEITEREN SCHREIBEN",
+      "refresh": "AKTUALISIEREN"
     }
   },
   "verify": {
@@ -357,7 +361,8 @@
       "performance": "LEISTUNG",
       "display": "ANZEIGE",
       "behavior": "VERHALTEN",
-      "catalog": "KATALOG"
+      "catalog": "KATALOG",
+      "diagnostics": "DIAGNOSE"
     },
     "label": {
       "writer_impl": "SCHREIBER",
@@ -373,7 +378,8 @@
       "auto_eject": "AUTO-AUSWURF",
       "auto_clear_done_seconds": "AUTO. FERTIGE LÖSCHEN",
       "catalog_url": "KATALOG-URL",
-      "catalog_refresh_hours": "KATALOG-AKTUALISIERUNG"
+      "catalog_refresh_hours": "KATALOG-AKTUALISIERUNG",
+      "debug_logging": "AUSFÜHRLICHE PROTOKOLLIERUNG"
     },
     "catalog_refresh": {
       "off": "NUR MANUELL",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -190,6 +190,9 @@
     "burn_needs_arm": "Toggle the destructive-write banner above to arm this burn.",
     "delete": "DELETE"
   },
+  "scan": {
+    "scanning": "SCANNING IMAGE"
+  },
   "detail": {
     "block": {
       "image": "IMAGE",
@@ -221,7 +224,8 @@
       "open_log": "OPEN LOG",
       "eject": "EJECT",
       "copy_hash": "COPY HASH",
-      "flash_another": "FLASH ANOTHER"
+      "flash_another": "FLASH ANOTHER",
+      "refresh": "REFRESH"
     }
   },
   "verify": {
@@ -357,7 +361,8 @@
       "performance": "PERFORMANCE",
       "display": "DISPLAY",
       "behavior": "BEHAVIOR",
-      "catalog": "CATALOG"
+      "catalog": "CATALOG",
+      "diagnostics": "DIAGNOSTICS"
     },
     "label": {
       "writer_impl": "WRITER IMPL",
@@ -373,7 +378,8 @@
       "auto_eject": "AUTO EJECT",
       "auto_clear_done_seconds": "AUTO CLEAR DONE",
       "catalog_url": "CATALOG URL",
-      "catalog_refresh_hours": "CATALOG REFRESH"
+      "catalog_refresh_hours": "CATALOG REFRESH",
+      "debug_logging": "VERBOSE LOGGING"
     },
     "catalog_refresh": {
       "off": "MANUAL ONLY",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -190,6 +190,9 @@
     "burn_needs_arm": "Active el aviso de escritura destructiva para armar este grabado.",
     "delete": "ELIMINAR"
   },
+  "scan": {
+    "scanning": "ESCANEANDO IMAGEN"
+  },
   "detail": {
     "block": {
       "image": "IMAGEN",
@@ -221,7 +224,8 @@
       "open_log": "ABRIR LOG",
       "eject": "EXPULSAR",
       "copy_hash": "COPIAR HASH",
-      "flash_another": "GRABAR OTRO"
+      "flash_another": "GRABAR OTRO",
+      "refresh": "ACTUALIZAR"
     }
   },
   "verify": {
@@ -357,7 +361,8 @@
       "performance": "RENDIMIENTO",
       "display": "PANTALLA",
       "behavior": "COMPORTAMIENTO",
-      "catalog": "CATÁLOGO"
+      "catalog": "CATÁLOGO",
+      "diagnostics": "DIAGNÓSTICO"
     },
     "label": {
       "writer_impl": "ESCRITOR",
@@ -373,7 +378,8 @@
       "auto_eject": "AUTO EXPULSAR",
       "auto_clear_done_seconds": "AUTO LIMPIAR HECHO",
       "catalog_url": "URL DEL CATÁLOGO",
-      "catalog_refresh_hours": "ACTUALIZAR CATÁLOGO"
+      "catalog_refresh_hours": "ACTUALIZAR CATÁLOGO",
+      "debug_logging": "REGISTRO DETALLADO"
     },
     "catalog_refresh": {
       "off": "SOLO MANUAL",

--- a/src/store/queue.js
+++ b/src/store/queue.js
@@ -397,6 +397,60 @@ export const useQueueStore = create((set, get) => ({
       return { jobs: { ...s.jobs, [jobId]: { ...j, boot: boot || null } } };
     });
   },
+
+  // Patch the row's deep-scan progress. `null` clears the bar; `{done,
+  // total}` drives it. Cleared explicitly on scan-complete so the row
+  // returns to its normal layout without the progress strip.
+  applyScanProgress(jobId, scanProgress) {
+    set((s) => {
+      const j = s.jobs[jobId];
+      if (!j) return s;
+      return { jobs: { ...s.jobs, [jobId]: { ...j, scanProgress } } };
+    });
+  },
+
+  // Patch one partition's filesystem label as the scan worker discovers
+  // it. Keeps the rest of the partition entry intact so the table only
+  // refreshes the column that actually changed.
+  applyPartitionFs(jobId, partitionIndex, filesystem) {
+    set((s) => {
+      const j = s.jobs[jobId];
+      if (!j || !j.partitions || !Array.isArray(j.partitions.partitions)) return s;
+      const next = j.partitions.partitions.map((p) =>
+        p.index === partitionIndex ? { ...p, filesystem: filesystem || null } : p
+      );
+      return {
+        jobs: {
+          ...s.jobs,
+          [jobId]: { ...j, partitions: { ...j.partitions, partitions: next } },
+        },
+      };
+    });
+  },
+
+  // Patch the row's image data in place after a re-scan, and reset the
+  // downstream probe fields so the UI shows "pending" while the validation
+  // and partition/boot probes re-run. Identity / target / queue position
+  // are preserved — this is distinct from removing and re-adding the row.
+  refreshImage(jobId, image) {
+    set((s) => {
+      const j = s.jobs[jobId];
+      if (!j) return s;
+      return {
+        jobs: {
+          ...s.jobs,
+          [jobId]: {
+            ...j,
+            image,
+            validation: 'pending',
+            validationDetail: null,
+            partitions: null,
+            boot: null,
+          },
+        },
+      };
+    });
+  },
 }));
 
 // Selectors -- co-located so consumers import one symbol per concern.
@@ -457,6 +511,31 @@ export function attachQueueListeners({ onFdaError, onImageInvalid } = {}) {
     });
   }).then((u) => subs.push(u));
 
+  // Deep-scan progressive events — see src-tauri/src/image_scan.rs.
+  // `image-scan-progress` drives the strip under the row; partition-fs
+  // fills filesystem labels as superblock samples land; complete clears
+  // the strip and the row settles into its final state.
+  listen('disk-cutter://image-scan-progress', (e) => {
+    if (!mounted) return;
+    const p = e.payload;
+    useQueueStore.getState().applyScanProgress(p.job_id, {
+      done: p.bytes_done,
+      total: p.bytes_total,
+    });
+  }).then((u) => subs.push(u));
+
+  listen('disk-cutter://image-scan-partition-fs', (e) => {
+    if (!mounted) return;
+    const p = e.payload;
+    useQueueStore.getState().applyPartitionFs(p.job_id, p.partition_index, p.filesystem);
+  }).then((u) => subs.push(u));
+
+  listen('disk-cutter://image-scan-complete', (e) => {
+    if (!mounted) return;
+    const p = e.payload;
+    useQueueStore.getState().applyScanProgress(p.job_id, null);
+  }).then((u) => subs.push(u));
+
   return () => {
     mounted = false;
     subs.forEach((u) => u());
@@ -469,4 +548,20 @@ export function attachQueueListeners({ onFdaError, onImageInvalid } = {}) {
 export function startValidation(jobId, path) {
   return invoke('validate_image_contents', { jobId, path })
     .catch((e) => console.error('validate_image_contents failed', e));
+}
+
+// Kicks off the deep-scan backend worker for this row. The worker short-
+// circuits when the image already has a fresh cached scan, so it is safe
+// to call after every add and after every REFRESH; subsequent jobs that
+// point at the same image hit the cache.
+export function startScan(jobId, path) {
+  return invoke('scan_image_for_row', { jobId, imagePath: path })
+    .catch((e) => console.error('scan_image_for_row failed', e));
+}
+
+// Invalidate the cached scan for an image path so the next add/expand
+// triggers a fresh pass. Wired to the REFRESH button in JobDetail.
+export function clearScanCache(path) {
+  return invoke('image_scan_clear', { imagePath: path })
+    .catch((e) => console.error('image_scan_clear failed', e));
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -657,6 +657,19 @@ input,select{font:inherit;color:inherit}
 .job-log-level{font-weight:700;letter-spacing:.04em;color:var(--ink-2)}
 .job-log-line--warn .job-log-level{color:#a0670c}
 .job-log-line--error .job-log-level{color:var(--hazard)}
+.job-log-line--debug .job-log-level,.job-log-line--debug .job-log-msg{color:var(--mute)}
+
+/* Deep-scan progress strip — sits between the row's main line and the
+   expanded detail. Visible only while a scan is in flight. */
+.scan-strip{
+  display:grid;grid-template-columns:auto 1fr auto;gap:10px;align-items:center;
+  padding:5px 14px;border-top:1.5px dashed var(--ink-2);
+  background:var(--bone);color:var(--ink-2);font-size:10.5px;letter-spacing:.06em;
+}
+.scan-strip-label{font-weight:700;color:var(--ink-2)}
+.scan-strip-bar{position:relative;height:4px;background:rgba(0,0,0,.08);overflow:hidden}
+.scan-strip-fill{position:absolute;inset:0 auto 0 0;background:var(--accent,#3a3a3a);transition:width .2s ease}
+.scan-strip-pct{font-variant-numeric:tabular-nums;color:var(--ink-2);min-width:36px;text-align:right}
 .job-log-msg{white-space:pre-wrap;word-break:break-word;color:var(--ink)}
 
 .kv{display:grid;grid-template-columns:160px 1fr;gap:14px;align-items:baseline;font-size:12.5px;line-height:1.5}


### PR DESCRIPTION
Stacked on #3 (`feat/decoder-chain`). Three interlocking pieces that build on the new decoder chain to give the queue real observability + caching.

## Summary

- **Per-row debug logging** — `VERBOSE LOGGING` toggle in Preferences drives a `JobLogger` trait whose entries land in each row's `burn_logs`. Decoder chain instrumented with magic-byte dumps, per-format probe results, and a final chain summary. Helper subprocess emits log lines as JSONL the parent forwards to the right row.
- **Compressed-source partition probes (bug fix)** — `DiskImage` for `.gz / .xz / .bz2 / .zst` now runs partition / boot / validate over a `PrefixBlockView` of the slurped decompressed prefix. Fixes long-standing "unrecognised filesystem" verdict on compressed images. Four-format coverage test added.
- **`image_scans` cache + eager-on-add scan + progressive UI** — new migration `0003_image_scans.sql` keyed by `image_path`, freshness via size + mtime. Single sequential pass collects 64 KB superblock samples at each partition's start LBA, stopping at `last_partition_start + 64 KB`. Per-partition filesystem labels flow through `image-scan-progress` / `image-scan-partition-fs` / `image-scan-complete` events. UI shows a slim progress strip between row and expanded detail; `REFRESH` button invalidates and re-runs.

Three-phase plan + open trade-offs documented in `docs/status.md` — Phase 2 temp-file materialization (only when `copies > 1`, burn-time, ref-counted, 50% guardrail) and Phase 3 per-format `DiskOffset` for partition extraction are sketched but not implemented.

## Test plan

- [x] `cargo test --lib` — 446 lib tests pass (includes new `compressed_formats_surface_partition_table_through_prefix_view`, `img_xz_chain_yields_xz_then_raw_with_expected_log_lines`, `parse_helper_line_log_*`, scanner sparse-view test, joblog level round-trip)
- [x] `cargo test` — full integration suite passes (7 burn-integration tests + lib)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `node scripts/check-i18n.mjs` — en / de / es parity
- [x] `npm test` — 194 frontend tests pass
- [x] Live `.img.xz` smoke test through the rebuilt `.app`: scan strip appears under the row, fills as the chain advances, partition table populates with `ext4 / FAT32 / etc.` labels after the scan reaches each partition's start LBA
- [ ] CI pipeline (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)