### PR TITLE
fix(doctor): unique tempfile per check_app_data_writable call

### DIFF
--- a/src-tauri/src/doctor.rs
+++ b/src-tauri/src/doctor.rs
@@ -193,14 +193,28 @@ fn check_eject_backend() -> Check {
 }
 
 fn check_app_data_writable() -> Check {
-    let dir = std::env::temp_dir().join("disk-cutter-doctor-write");
-    let result = std::fs::write(&dir, b"ok").and_then(|_| std::fs::remove_file(&dir));
+    // Unique-per-call filename so parallel callers (the test suite, two
+    // doctor instances, two running app processes) don't race on a shared
+    // path. A fixed name like "disk-cutter-doctor-write" caused
+    // intermittent Fail verdicts when one caller's `remove_file` deleted
+    // the file out from under another caller's pending `write`/`remove`
+    // sequence.
+    let name = format!(
+        "disk-cutter-doctor-write-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    );
+    let path = std::env::temp_dir().join(name);
+    let result = std::fs::write(&path, b"ok").and_then(|_| std::fs::remove_file(&path));
     match result {
         Ok(_) => Check::pass(
             "tmpdir",
             "Temp directory writable",
             "core",
-            &format!("wrote {} successfully", dir.display()),
+            &format!("wrote {} successfully", path.display()),
         ),
         Err(e) => Check::fail(
             "tmpdir",


### PR DESCRIPTION
## Summary
Race fix for the doctor self-diagnostic check that ensures the OS tempdir is writable. Replaces the fixed shared path `disk-cutter-doctor-write` with a per-call name interpolating \`std::process::id()\` and \`SystemTime::now().as_nanos()\`.

## Why
The fixed path caused intermittent \`Fail\` verdicts whenever two callers ran the check concurrently — most commonly in the test suite (\`cargo test --lib\` runs tests in parallel), but also possible across two running app processes or two doctor probes. The race:

\`\`\`
thread A: write(path)        → OK
thread B: write(path)        → OK
thread A: remove_file(path)  → OK   (file gone)
thread B: remove_file(path)  → Err(ENOENT)   ← unexpected Fail
\`\`\`

## Test plan
- [x] \`cargo test --lib doctor::tests::check_app_data_writable_returns_a_check\` — passes
- [x] Full \`cargo test --lib\` (446 tests) — passes
- [x] 5 consecutive full lib-suite runs — all pass (previously reproduced the failure within 1-2 runs)
- [x] \`cargo fmt --check\`, \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`node scripts/check-i18n.mjs\` — parity

## Why this matters
Pre-push hook landing in the next PR (#5 / \`hooks/add-pre-push\`) runs the full test suite on every \`git push\`. With this race still in place, the hook produced false positives on its own first push, undermining the gate. Land this first → pre-push hook becomes a reliable signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)