### PR TITLE
chore(hooks): add pre-push hook for cargo + npm tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Pre-push hook — runs the test suites CI enforces, so a push doesn't
+# fail on something we could have caught locally in 30-60s.
+#
+# This is the second gate on top of .githooks/pre-commit (fmt + clippy +
+# i18n parity). Pre-push is the right layer for tests: agents commit
+# frequently while iterating; the toll is paid once per push instead
+# of once per commit.
+#
+# Note: tests run only against the host OS — windows-only and linux-only
+# bugs still need the CI matrix to surface. This hook catches the
+# regressions you can catch locally, nothing more.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+# or:
+#   ./scripts/install-hooks.sh
+#
+# Skip for a single push (use sparingly):
+#   git push --no-verify
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "[pre-push] cargo test"
+cargo test --manifest-path "$REPO_ROOT/src-tauri/Cargo.toml"
+
+echo "[pre-push] npm test"
+cd "$REPO_ROOT"
+npm test --silent
+
+echo "[pre-push] OK"


### PR DESCRIPTION
Second gate on top of the existing pre-commit hook. Pre-commit catches the fast stuff (fmt, clippy, i18n parity); pre-push runs the actual test suites so a \`git push\` doesn't fail on a regression a local run could have caught.

## Summary
- New \`.githooks/pre-push\` running \`cargo test --manifest-path src-tauri/Cargo.toml\` and \`npm test\`.
- Same activation as pre-commit: \`git config core.hooksPath .githooks\` (auto-applied by \`scripts/install-hooks.sh\` on \`npm install\` via the \`prepare\` script).
- Bypass for a single push with \`git push --no-verify\`.

## Why
For AI-driven workflows where commits are cheap and bad pushes trigger CI runs / pollute the signal CI provides, a 30–60s local toll on the actor that introduced the regression is the right place for feedback. The toll discourages pushing broken code without forcing tests on every commit.

## Test plan
- [x] Hook validates its own first push — passes cleanly now that PR #5 fixed the doctor tempdir-race flake
- [x] \`bash .githooks/pre-push\` from worktree root passes (cargo test 446 lib + 7 integration; npm test 194)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)