### PR TITLE
chore: drop tauri/vite dev-server config + scripts + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # `tauri::generate_context!()` checks `frontendDist` exists at
+      # compile time. Without devUrl set in tauri.conf.json (which is the
+      # standing project decision — single supported run-mode), every
+      # cargo invocation that compiles the lib needs `dist/` on disk.
+      # Build the frontend bundle once before clippy + test.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: npm install
+        run: npm install
+
+      - name: Frontend build (produces dist/ for tauri::generate_context!)
+        run: npm run build
+
       - name: cargo fmt --check
         run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,6 @@ bash scripts/install-hooks.sh       # registers .githooks/pre-commit
 Day-to-day:
 
 ```sh
-npx tauri dev                                          # hot-reload dev build
 npx tauri build                                        # release .app/.dmg
 cargo check --manifest-path src-tauri/Cargo.toml       # fast Rust iteration
 cargo test  --manifest-path src-tauri/Cargo.toml       # backend tests
@@ -52,9 +51,9 @@ npm test                                               # frontend Vitest
 npm run build                                          # frontend production bundle
 ```
 
-`npx tauri dev` is the right command 90% of the time. Reach for `cargo
-check`/`cargo test` directly when you're iterating on Rust internals and
-don't need to launch the UI.
+The release `.app` bundle is the only supported run-mode. There is no
+dev server — `tauri dev` / `vite` have been removed from the project
+configuration on purpose; iterate by rebuilding.
 
 ## Coding standards
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ macOS-only for now.
 
 ```sh
 npm install
-npx tauri dev          # hot-reloads UI + Rust
 npx tauri build        # bundled .app / .dmg in src-tauri/target/release/bundle
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   },
   "scripts": {
     "prepare": "./scripts/install-hooks.sh || true",
-    "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,8 +4,6 @@
   "version": "0.5.0-alpha",
   "identifier": "com.diskcutter.app",
   "build": {
-    "beforeDevCommand": "npm run dev",
-    "devUrl": "http://127.0.0.1:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },


### PR DESCRIPTION
## Summary
Removes every entry point to the dev-server modes so the project has a single supported run-mode: release-build the \`.app\` bundle and launch it.

- \`tauri.conf.json\` → drops \`build.beforeDevCommand\` + \`build.devUrl\`
- \`package.json\` → drops \`scripts.dev\` (vite) + \`scripts.preview\`
- \`CONTRIBUTING.md\` → drops the \`npx tauri dev\` recipe + the advisory that called it "the right command 90% of the time"; replaces with explicit "release \`.app\` bundle is the only supported run-mode"
- \`README.md\` → drops the \`npx tauri dev\` line from the install/run snippet

## Why
\`tauri dev\` produces a debug build that doesn't carry the release \`.app\`'s entitlements (FDA, raw-device access, etc.) and behaves subtly differently from what ships. Iterating in dev mode then shipping a release bundle means catching dev-only / release-only divergence at release time — exactly the wrong order. Removing the entry points makes the supported path the only path.

For fast inner loops that don't need the UI, \`cargo check\` / \`cargo test\` / \`npm test\` remain as before.

## Test plan
- [x] Pre-push hook validated locally (\`cargo test\` + \`npm test\` pass)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)