### PR TITLE
feat(image-scan): filesystem volume labels + queue alignment fixes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,7 +14,7 @@
 
 use std::path::Path;
 
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::db::{self, Db};
 use crate::forensic::{self, HostInfo};
@@ -55,6 +55,31 @@ pub fn inspect_image_partitions(
     std::thread::spawn(move || {
         let log = crate::joblog::db_logger_for(&app, &job_id);
         log.debug("scan: partition probe starting");
+        // Prefer the deep-scan cache when it's fresh — its
+        // partition_table covers filesystem labels for every
+        // partition, including those past the prefix probe's
+        // ~33 KB window. Without this, an app restart re-runs the
+        // prefix-only probe and overwrites the cached full data
+        // with partitions whose filesystem is null for everything
+        // past the prefix, so the UI shows the partition-type
+        // label ("Linux filesystem") instead of "ext4" / "FAT32".
+        let cached = db::image_scan_get(&app.state::<Db>(), &path)
+            .filter(|r| r.scan_complete && db::image_scan_is_fresh(r))
+            .and_then(|r| r.partition_table)
+            .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok());
+        if let Some(summary) = cached {
+            log.info("scan: partition probe served from deep-scan cache");
+            #[derive(serde::Serialize, Clone)]
+            struct CachedPayload {
+                job_id: String,
+                summary: serde_json::Value,
+            }
+            let _ = app.emit(
+                "disk-cutter://image-partitioned",
+                CachedPayload { job_id, summary },
+            );
+            return;
+        }
         let summary = DiskImage::open_with_log(Path::new(&path), &log)
             .ok()
             .and_then(|img| img.partitions().cloned());

--- a/src-tauri/src/image.rs
+++ b/src-tauri/src/image.rs
@@ -362,7 +362,9 @@ fn summarise(dev: &dyn BlockRead) -> partitions::Result<PartitionSummary> {
     let mut out = Vec::with_capacity(parts.len());
     for (i, p) in parts.iter().enumerate() {
         let fs = partitions::sniff::sniff(dev, p).ok();
-        out.push(make_part_info((i + 1) as u32, p, fs));
+        let mut info = make_part_info((i + 1) as u32, p, fs);
+        info.fs_label = fs.and_then(|kind| read_fs_label(dev, p, kind));
+        out.push(info);
     }
     let any_bootable = out.iter().any(|p| p.bootable);
     Ok(PartitionSummary {
@@ -370,6 +372,23 @@ fn summarise(dev: &dyn BlockRead) -> partitions::Result<PartitionSummary> {
         partitions: out,
         any_bootable,
     })
+}
+
+/// Read up to 64 KB from the partition start and let the inspect
+/// parser pull out a volume label. Errors / short reads silently
+/// produce `None` — labels are decorative.
+fn read_fs_label(
+    dev: &dyn BlockRead,
+    p: &partitions::probe::Partition,
+    kind: partitions::sniff::FsKind,
+) -> Option<String> {
+    let take = (64 * 1024u64).min(p.length) as usize;
+    if take == 0 {
+        return None;
+    }
+    let mut buf = vec![0u8; take];
+    dev.read_at(p.start, &mut buf).ok()?;
+    crate::inspect::fs_label_from_sample(kind, &buf)
 }
 
 /// Walk every boot signal the image carries.

--- a/src-tauri/src/image_scan.rs
+++ b/src-tauri/src/image_scan.rs
@@ -60,6 +60,7 @@ struct PartitionFsPayload {
     image_path: String,
     partition_index: u32,
     filesystem: Option<String>,
+    fs_label: Option<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -86,6 +87,33 @@ impl SparseSampleView {
             .unwrap_or(0);
         Self { ranges, end }
     }
+
+    /// Return the slice of the captured sample whose range contains
+    /// `offset`, together with the position of `offset` inside that
+    /// slice. `None` if no captured range covers it.
+    fn sample_at(&self, offset: u64) -> Option<&[u8]> {
+        for (sample_start, sample_bytes) in &self.ranges {
+            let sample_end = sample_start + sample_bytes.len() as u64;
+            if offset >= *sample_start && offset < sample_end {
+                let rel = (offset - sample_start) as usize;
+                return Some(&sample_bytes[rel..]);
+            }
+        }
+        None
+    }
+}
+
+/// Find the captured bytes for a partition and run the FS-label
+/// parser against them. Returns `None` when we never sampled the
+/// partition's start (e.g. partition begins past `stop_at`) or when
+/// the parser doesn't support `kind`.
+fn fs_label_for_partition(
+    view: &SparseSampleView,
+    partition_start: u64,
+    kind: partitions::sniff::FsKind,
+) -> Option<String> {
+    let sample = view.sample_at(partition_start)?;
+    crate::inspect::fs_label_from_sample(kind, sample)
 }
 
 impl fs_core::BlockRead for SparseSampleView {
@@ -333,14 +361,23 @@ fn run_scan(app: &AppHandle, job_id: &str, image_path: &str) -> Result<(), Strin
     };
     for (idx, p) in parts_raw.iter().enumerate() {
         let fs = partitions::sniff::sniff(&view, p).ok();
-        let fs_label: Option<String> = fs.map(crate::inspect::format_fs_kind);
+        let filesystem: Option<String> = fs.map(crate::inspect::format_fs_kind);
+        // Pull the volume label out of the same bytes we collected for
+        // this partition: either the prefix slurp (if the partition
+        // starts inside the first PREFIX_BYTES) or its own per-partition
+        // sample. Looking up the range directly avoids the
+        // `view.read_at` OutOfBounds case for partitions whose length
+        // is smaller than the requested read.
+        let fs_label: Option<String> =
+            fs.and_then(|kind| fs_label_for_partition(&view, p.start, kind));
         let partition_index = (idx + 1) as u32;
         if let Some(part_info) = summary
             .partitions
             .iter_mut()
             .find(|p| p.index == partition_index)
         {
-            part_info.filesystem = fs_label.clone();
+            part_info.filesystem = filesystem.clone();
+            part_info.fs_label = fs_label.clone();
         }
         let _ = app.emit(
             "disk-cutter://image-scan-partition-fs",
@@ -348,7 +385,8 @@ fn run_scan(app: &AppHandle, job_id: &str, image_path: &str) -> Result<(), Strin
                 job_id: job_id.to_string(),
                 image_path: image_path.to_string(),
                 partition_index,
-                filesystem: fs_label,
+                filesystem,
+                fs_label,
             },
         );
     }

--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -46,9 +46,19 @@ pub struct PartInfo {
     pub size_human: String,
     pub kind_label: String,
     pub type_id: String,
+    /// Partition-table label — the GPT partition entry name. Always
+    /// `None` for MBR (no name field). Distinct from `fs_label` because
+    /// the two can differ (e.g. GPT entry named "rootfs" containing an
+    /// ext4 filesystem with `s_volume_name = "RPI-ROOT"`).
     pub label: Option<String>,
     pub uuid: Option<String>,
     pub filesystem: Option<String>,
+    /// Volume label parsed out of the filesystem superblock — ext
+    /// `s_volume_name`, FAT `BS_VolLab`, ISO 9660 PVD identifier. None
+    /// for filesystems whose label lives in MFT/catalog records
+    /// (NTFS, exFAT, APFS, HFS+) since we only sample 64 KB at the
+    /// partition start.
+    pub fs_label: Option<String>,
     /// True when the on-disk table marks this partition bootable:
     /// MBR active flag set, GPT legacy-BIOS-bootable attribute set, or
     /// GPT type is the EFI System Partition GUID. Comes from
@@ -119,7 +129,10 @@ fn summarise(dev: &dyn BlockRead) -> partitions::Result<PartitionSummary> {
     let mut out = Vec::with_capacity(parts.len());
     for (i, p) in parts.iter().enumerate() {
         let fs = sniff(dev, p).ok();
-        out.push(make_part_info((i + 1) as u32, p, fs));
+        let fs_label = fs.and_then(|k| read_fs_label_from_block(dev, p, k));
+        let mut info = make_part_info((i + 1) as u32, p, fs);
+        info.fs_label = fs_label;
+        out.push(info);
     }
     let any_bootable = out.iter().any(|p| p.bootable);
     Ok(PartitionSummary {
@@ -127,6 +140,86 @@ fn summarise(dev: &dyn BlockRead) -> partitions::Result<PartitionSummary> {
         partitions: out,
         any_bootable,
     })
+}
+
+/// Pull just enough bytes from the partition start to cover every
+/// signature `fs_label_from_sample` parses (ISO 9660's PVD lives at
+/// +32768) and run the parser. Failures (read errors, partition too
+/// short) silently return `None` — fs labels are nice-to-have, not
+/// load-bearing.
+fn read_fs_label_from_block(dev: &dyn BlockRead, p: &Partition, kind: FsKind) -> Option<String> {
+    let want = 64 * 1024u64;
+    let take = want.min(p.length) as usize;
+    if take == 0 {
+        return None;
+    }
+    let mut buf = vec![0u8; take];
+    dev.read_at(p.start, &mut buf).ok()?;
+    fs_label_from_sample(kind, &buf)
+}
+
+/// Parse the volume label out of a buffer that starts at the
+/// partition's first byte. Returns `None` for filesystems whose label
+/// can't be reached from a 64 KB superblock sample (NTFS, exFAT, APFS,
+/// HFS+), for empty/default labels (FAT "NO NAME"), and when the
+/// buffer is too short to reach the label offset.
+pub fn fs_label_from_sample(kind: FsKind, buf: &[u8]) -> Option<String> {
+    match kind {
+        FsKind::Ext { .. } => ext_volume_label(buf),
+        FsKind::Fat32 => fat_volume_label(buf, 71),
+        FsKind::Fat16 => fat_volume_label(buf, 43),
+        FsKind::Iso9660 => iso9660_volume_label(buf),
+        _ => None,
+    }
+}
+
+fn ext_volume_label(buf: &[u8]) -> Option<String> {
+    const SB_OFFSET: usize = 1024;
+    const VOLUME_NAME_OFFSET: usize = 0x78;
+    const VOLUME_NAME_LEN: usize = 16;
+    let start = SB_OFFSET + VOLUME_NAME_OFFSET;
+    let raw = buf.get(start..start + VOLUME_NAME_LEN)?;
+    let end = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+    let s = String::from_utf8_lossy(&raw[..end]).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn fat_volume_label(buf: &[u8], offset: usize) -> Option<String> {
+    let raw = buf.get(offset..offset + 11)?;
+    // FAT labels are stored as CP437 space-padded. Pi-ecosystem labels
+    // are pure ASCII so a lossy UTF-8 decode is fine in practice; if a
+    // weird codepoint sneaks in it renders as U+FFFD rather than
+    // breaking the row.
+    let s = String::from_utf8_lossy(raw)
+        .trim_end_matches(' ')
+        .to_string();
+    if s.is_empty() || s == "NO NAME" {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn iso9660_volume_label(buf: &[u8]) -> Option<String> {
+    // Primary Volume Descriptor at LBA 16 (32 KiB); volume_identifier
+    // is 32 bytes of ASCII (space-padded) at +40.
+    const PVD_OFFSET: usize = 32768;
+    const VOL_ID_OFFSET: usize = 40;
+    const VOL_ID_LEN: usize = 32;
+    let start = PVD_OFFSET + VOL_ID_OFFSET;
+    let raw = buf.get(start..start + VOL_ID_LEN)?;
+    let s = String::from_utf8_lossy(raw)
+        .trim_end_matches(' ')
+        .to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
 }
 
 pub fn table_kind_label(t: TableKind) -> &'static str {
@@ -160,6 +253,7 @@ pub fn make_part_info(index: u32, p: &Partition, fs: Option<FsKind>) -> PartInfo
         label: p.label.clone(),
         uuid: p.uuid.map(|b| format_guid(&b)),
         filesystem: fs.map(format_fs_kind),
+        fs_label: None,
         bootable: p.is_bootable(),
     }
 }
@@ -359,6 +453,98 @@ mod tests {
         // SquashFS magic at offset 0
         let sqsh = b"hsqs\x00\x00\x00\x00";
         assert_eq!(classify_buffer(sqsh).as_deref(), Some("SquashFS"));
+    }
+
+    #[test]
+    fn fs_label_reads_ext_volume_name() {
+        let mut buf = vec![0u8; 2048];
+        // s_volume_name at offset 1024 + 0x78, null-padded 16 bytes.
+        let off = 1024 + 0x78;
+        buf[off..off + 8].copy_from_slice(b"RPI-ROOT");
+        assert_eq!(
+            fs_label_from_sample(
+                FsKind::Ext {
+                    version: ExtVersion::Ext4
+                },
+                &buf
+            )
+            .as_deref(),
+            Some("RPI-ROOT")
+        );
+    }
+
+    #[test]
+    fn fs_label_handles_empty_ext_volume_name() {
+        let buf = vec![0u8; 2048];
+        assert!(fs_label_from_sample(
+            FsKind::Ext {
+                version: ExtVersion::Ext4
+            },
+            &buf
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn fs_label_reads_fat32_volume_label() {
+        let mut buf = vec![0u8; 512];
+        // BS_VolLab at offset 71, 11 bytes, space-padded.
+        buf[71..71 + 11].copy_from_slice(b"BOOT       ");
+        assert_eq!(
+            fs_label_from_sample(FsKind::Fat32, &buf).as_deref(),
+            Some("BOOT")
+        );
+    }
+
+    #[test]
+    fn fs_label_ignores_fat_no_name_default() {
+        let mut buf = vec![0u8; 512];
+        buf[71..71 + 11].copy_from_slice(b"NO NAME    ");
+        assert!(fs_label_from_sample(FsKind::Fat32, &buf).is_none());
+    }
+
+    #[test]
+    fn fs_label_reads_fat16_volume_label() {
+        let mut buf = vec![0u8; 512];
+        buf[43..43 + 11].copy_from_slice(b"USBDATA    ");
+        assert_eq!(
+            fs_label_from_sample(FsKind::Fat16, &buf).as_deref(),
+            Some("USBDATA")
+        );
+    }
+
+    #[test]
+    fn fs_label_reads_iso9660_volume_identifier() {
+        let mut buf = vec![0u8; 64 * 1024];
+        let off = 32768 + 40;
+        let label = b"DEBIAN-12.2.0";
+        buf[off..off + label.len()].copy_from_slice(label);
+        for b in &mut buf[off + label.len()..off + 32] {
+            *b = b' ';
+        }
+        assert_eq!(
+            fs_label_from_sample(FsKind::Iso9660, &buf).as_deref(),
+            Some("DEBIAN-12.2.0")
+        );
+    }
+
+    #[test]
+    fn fs_label_returns_none_for_unsupported_kinds() {
+        let buf = vec![0u8; 64 * 1024];
+        assert!(fs_label_from_sample(FsKind::Ntfs, &buf).is_none());
+        assert!(fs_label_from_sample(FsKind::ExFat, &buf).is_none());
+        assert!(fs_label_from_sample(FsKind::Apfs, &buf).is_none());
+        assert!(fs_label_from_sample(FsKind::HfsPlus, &buf).is_none());
+        assert!(fs_label_from_sample(FsKind::Squashfs, &buf).is_none());
+        assert!(fs_label_from_sample(FsKind::LinuxSwap, &buf).is_none());
+        assert!(fs_label_from_sample(FsKind::Unknown, &buf).is_none());
+    }
+
+    #[test]
+    fn fs_label_returns_none_when_buffer_too_short() {
+        // Short buffer can't reach the ISO9660 PVD at 32 KiB.
+        let buf = vec![0u8; 1024];
+        assert!(fs_label_from_sample(FsKind::Iso9660, &buf).is_none());
     }
 
     #[test]

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -4,7 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import i18n, { availableLanguages } from './i18n/index.js';
-import { formatBytes, formatBps, formatDuration } from './format.js';
+import { formatBytes, formatBytesCompact, formatBytesExtended, formatBps, formatDuration } from './format.js';
 import logoUrl from './assets/logo.svg';
 
 const winCtl = {
@@ -465,7 +465,7 @@ function JobRow({ job, accent, expanded, onToggle, onSelectTarget, onBurn, onCan
         <div className="job-image">
           <div className="job-image-name">{job.image.name}</div>
           <div className="job-image-meta">
-            <span>{job.image.size}</span>
+            <span>{formatBytesCompact(job.image.bytes)}</span>
             <ValidationBadge validation={job.validation} detail={job.validationDetail} />
           </div>
         </div>
@@ -669,13 +669,7 @@ function JobDetail({ job, accent, onCancel, onRetry, onRefresh, fdaBlocked, conf
       <div className="detail-grid">
         <DetailBlock label={t('detail.block.image')}>
           <KV k={t('detail.kv.path')} v={job.image.path} mono />
-          <KV
-            k={t('detail.kv.size')}
-            v={job.image.size
-              ? t('detail.kv.size_value', { size: job.image.size, bytes: (job.image.bytes ?? 0).toLocaleString() })
-              : (job.image.bytes != null ? `${job.image.bytes.toLocaleString()} bytes` : '—')}
-            mono
-          />
+          <KV k={t('detail.kv.size')} v={formatBytesExtended(job.image.bytes)} mono />
           <KV k={t('detail.kv.sectors')} v={job.image.sectors != null ? job.image.sectors.toLocaleString() : '—'} mono />
           <KV k={t('detail.kv.format')} v={job.image.format || '—'} />
           <KV k={t('detail.kv.sha256_source')} v={job.image.sha256 || '—'} mono wrap />

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -364,12 +364,17 @@ function buildPartitionSegments(parts, totalBytes) {
         title: 'unallocated',
       });
     }
+    // Prefer the filesystem volume label (ext s_volume_name, FAT
+    // BS_VolLab, ISO9660 PVD identifier) over the GPT partition entry
+    // name — for Pi images they're "bootfs"/"rootfs" in the FS only,
+    // and MBR partitions never carry a name field at all.
+    const displayLabel = p.fs_label || p.label || '';
     out.push({
       fsClass: fsClassFor(p.filesystem),
       length: p.length_bytes,
       sizeHuman: p.size_human,
-      label: p.label || p.filesystem || p.kind_label || '',
-      title: [p.label, p.filesystem || p.kind_label].filter(Boolean).join(' · ') || p.kind_label,
+      label: displayLabel || p.filesystem || p.kind_label || '',
+      title: [displayLabel, p.filesystem || p.kind_label].filter(Boolean).join(' · ') || p.kind_label,
       bootable: !!p.bootable,
     });
     cursor = p.start_bytes + p.length_bytes;
@@ -901,7 +906,7 @@ function PartitionTable({ partitions, validation, validationDetail, boot }) {
               <td className="mono">{p.size_human}</td>
               <td>{p.kind_label}</td>
               <td>{p.filesystem || '—'}</td>
-              <td>{p.label || '—'}</td>
+              <td>{p.fs_label || p.label || '—'}</td>
             </tr>
           ))}
         </tbody>

--- a/src/format.js
+++ b/src/format.js
@@ -6,6 +6,26 @@ export function formatBytes(n) {
   return `${n} B`;
 }
 
+// Compact human form for the queue row meta line: `31.98GB`. No
+// space inside the unit because the row is tight on horizontal
+// space and pairs the size with the validation chip — a tight glyph
+// reads more like one token alongside the chip.
+export function formatBytesCompact(n) {
+  if (n == null) return '—';
+  if (n >= 1e9) return `${(n / 1e9).toFixed(2)}GB`;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}MB`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}kB`;
+  return `${n}B`;
+}
+
+// "Human + exact" form for the expanded detail block: `31.98GB
+// (31,000,000,000 bytes)`. The detail view has room for both, and the
+// exact bytes matter when comparing image size to target capacity.
+export function formatBytesExtended(n) {
+  if (n == null) return '—';
+  return `${formatBytesCompact(n)} (${n.toLocaleString()} bytes)`;
+}
+
 export function formatBps(bps) {
   if (bps == null) return '—';
   if (bps >= 1e9) return `${(bps / 1e9).toFixed(2)} GB/s`;

--- a/src/store/queue.js
+++ b/src/store/queue.js
@@ -409,15 +409,17 @@ export const useQueueStore = create((set, get) => ({
     });
   },
 
-  // Patch one partition's filesystem label as the scan worker discovers
-  // it. Keeps the rest of the partition entry intact so the table only
-  // refreshes the column that actually changed.
-  applyPartitionFs(jobId, partitionIndex, filesystem) {
+  // Patch one partition's filesystem kind + volume label as the scan
+  // worker discovers them. Keeps the rest of the partition entry intact
+  // so the table only refreshes the columns that actually changed.
+  applyPartitionFs(jobId, partitionIndex, filesystem, fsLabel) {
     set((s) => {
       const j = s.jobs[jobId];
       if (!j || !j.partitions || !Array.isArray(j.partitions.partitions)) return s;
       const next = j.partitions.partitions.map((p) =>
-        p.index === partitionIndex ? { ...p, filesystem: filesystem || null } : p
+        p.index === partitionIndex
+          ? { ...p, filesystem: filesystem || null, fs_label: fsLabel || null }
+          : p
       );
       return {
         jobs: {
@@ -527,7 +529,7 @@ export function attachQueueListeners({ onFdaError, onImageInvalid } = {}) {
   listen('disk-cutter://image-scan-partition-fs', (e) => {
     if (!mounted) return;
     const p = e.payload;
-    useQueueStore.getState().applyPartitionFs(p.job_id, p.partition_index, p.filesystem);
+    useQueueStore.getState().applyPartitionFs(p.job_id, p.partition_index, p.filesystem, p.fs_label);
   }).then((u) => subs.push(u));
 
   listen('disk-cutter://image-scan-complete', (e) => {

--- a/src/store/queue.js
+++ b/src/store/queue.js
@@ -141,14 +141,22 @@ export const useQueueStore = create((set, get) => ({
         order.push(j.id);
       });
       set({ jobs, order });
-      // Re-kick image validation for any rehydrated idle row whose
-      // image_path looks usable. Without this, every queued row from
-      // a previous session sits at validation='pending' forever — the
-      // Burn button stays grey because the arm gate also checks valid.
+      // Re-kick image validation AND the deep scan for any rehydrated
+      // idle row whose image_path looks usable. Without validation,
+      // every queued row from a previous session sits at
+      // validation='pending' forever — the Burn button stays grey
+      // because the arm gate also checks valid. Without the deep scan,
+      // partitions whose start offset is past the validation prefix
+      // never get their filesystem sniffed, so the UI shows the
+      // partition-table kind label ("Linux filesystem") instead of
+      // the actual filesystem (ext4, FAT32 …). The deep-scan worker
+      // short-circuits on a fresh image_scans cache hit, so this is
+      // cheap when the image hasn't changed.
       for (const id of order) {
         const j = jobs[id];
         if (j.state === 'idle' && j.image && j.image.path) {
           startValidation(j.id, j.image.path);
+          startScan(j.id, j.image.path);
         }
       }
     } catch (e) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -429,7 +429,7 @@ input,select{font:inherit;color:inherit}
   gap:14px;align-items:center;padding:10px 12px;
 }
 .entry-icon{font-size:18px;text-align:center}
-.entry-image-name{font-family:var(--display);font-weight:700;font-size:14px}
+.entry-image-name{font-family:var(--display);font-weight:700;font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0}
 .entry-image-meta{color:var(--mute)}
 .entry-counter{font-weight:700;letter-spacing:.06em;text-align:right}
 .entry-dispatch{justify-self:end}
@@ -471,22 +471,33 @@ input,select{font:inherit;color:inherit}
 
 .queue{
   flex:1;min-height:0;overflow:auto;padding:0 28px 0;
+  /* Single grid spanning the header + every job row, so the image
+     column sizes against rows uniformly via subgrid. Header, entries
+     strip, and each .job descend into this grid via subgrid.
+     `minmax(0, 1fr)` on the image column (not bare `1fr`) — without
+     the explicit min, the column refuses to shrink below the longest
+     filename's intrinsic width, and a single non-wrapping filename
+     pushes the whole grid wider than the queue container, which in
+     turn forces every `grid-column: 1 / -1` element (.pstrip,
+     .job-detail, .scan-strip) past the right edge. minmax(0, …)
+     lets the cell shrink and clip; the filename cell handles the
+     visual truncation with text-overflow: ellipsis below. */
+  display:grid;
+  grid-template-columns: 28px 38px minmax(0, 1fr) 36px 280px 60px 200px 200px;
+  column-gap:16px;align-content:start;
 }
 
+.queue-entries{grid-column:1 / -1}
+
 .queue-head{
-  display:grid;
-  /* Mirror .job-head columns exactly so header labels line up with the
-     data cells. Leading column is the row chevron's gutter (left
-     empty in the header), trailing column is the remove button's
-     gutter. Keeping the two grids in sync is the only reason the
-     header reads as a header at all. */
-  grid-template-columns: 28px 38px 1fr 36px 280px 60px 200px 200px;
-  gap:16px;align-items:start;
+  display:grid;grid-template-columns:subgrid;grid-column:1 / -1;
+  align-items:start;
   padding:12px 4px;border-bottom:1.5px solid var(--ink);
   letter-spacing:.06em;color:var(--mute);font-weight:600;
 }
 
 .job{
+  display:grid;grid-template-columns:subgrid;grid-column:1 / -1;
   border-bottom:1.5px solid var(--ink);
   background:transparent;
   transition:background .14s;
@@ -495,9 +506,8 @@ input,select{font:inherit;color:inherit}
 .job--danger{background:rgba(255,74,23,.04)}
 
 .job-head{
-  display:grid;
-  grid-template-columns: 28px 38px 1fr 36px 280px 60px 200px 200px;
-  gap:16px;align-items:start;
+  display:grid;grid-template-columns:subgrid;grid-column:1 / -1;
+  align-items:start;
   padding:18px 4px;cursor:pointer;
 }
 .job--compact .job-head{padding:12px 4px}
@@ -510,8 +520,14 @@ input,select{font:inherit;color:inherit}
   padding:1px 8px;box-sizing:border-box;line-height:1.35;
 }
 
+/* The image cell holds the filename + meta. `min-width: 0` lets the
+   cell shrink below its content's intrinsic width, which is what
+   allows the child `.job-image-name`/`.entry-image-name` ellipsis to
+   actually engage — without it, grid/flex items default to
+   `min-width: auto` and refuse to clip. */
+.job-image,.entry-image{min-width:0}
 .job-image-name{font-family:var(--display);font-weight:700;font-size:15.5px;line-height:1.15;
-  letter-spacing:-.005em;word-break:break-all;}
+  letter-spacing:-.005em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
 .job-image-meta{display:flex;gap:6px;align-items:center;font-family:var(--mono);font-size:10.5px;
   color:var(--ink-2);margin-top:5px;letter-spacing:.03em;}
 .job-image-meta .dot{opacity:.4}
@@ -625,6 +641,7 @@ input,select{font:inherit;color:inherit}
 
 /* expanded drawer */
 .job-detail{
+  grid-column:1 / -1;
   border-top:1.5px solid var(--ink);background:var(--sidebar-bg);
   padding:20px 24px;
 }
@@ -669,6 +686,7 @@ input,select{font:inherit;color:inherit}
 /* Deep-scan progress strip — sits between the row's main line and the
    expanded detail. Visible only while a scan is in flight. */
 .scan-strip{
+  grid-column:1 / -1;
   display:grid;grid-template-columns:auto 1fr auto;gap:10px;align-items:center;
   padding:5px 14px;border-top:1.5px dashed var(--ink-2);
   background:var(--bone);color:var(--ink-2);font-size:10.5px;letter-spacing:.06em;
@@ -1161,6 +1179,7 @@ input,select{font:inherit;color:inherit}
    sized by length_bytes. Sits between .job-head and the expanded
    .job-detail so it doesn't fight the .job-head grid columns. */
 .pstrip{
+  grid-column:1 / -1;
   margin:6px 12px 8px 12px;
   display:flex;align-items:center;gap:10px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -634,6 +634,13 @@ input,select{font:inherit;color:inherit}
 .detail-block{
   border:1.5px solid var(--ink);background:var(--paper);
   padding:14px 16px;
+  /* Grid items default to min-width:auto, so an unbreakable token in
+     a descendant cell (long FS label, ISO9660 PVD identifier, raw
+     SHA hash) makes the block expand past its track and push the
+     whole row off the right edge of the window. min-width:0 plus
+     overflow-x clipping confines content to the assigned track. */
+  min-width:0;
+  overflow-x:hidden;
 }
 .detail-block--full{grid-column:1/-1}
 .detail-label{
@@ -1211,12 +1218,21 @@ input,select{font:inherit;color:inherit}
 
 /* ─────────── Partition Table (expanded detail) ─────────── */
 
-.ptable{display:flex;flex-direction:column;gap:6px}
+.ptable{display:flex;flex-direction:column;gap:6px;min-width:0}
 .ptable-head{
-  display:flex;align-items:center;gap:6px;
+  display:flex;align-items:center;gap:6px;flex-wrap:wrap;
   color:var(--mute);
 }
-.ptable .ver-table{margin-top:2px}
+.ptable .ver-table{margin-top:2px;width:100%}
+/* Long FS / partition labels and PVD identifiers can be 16-32 chars
+   of unbroken text. Let them wrap inside the cell instead of widening
+   the column. The mono cells (#, start, size) stay nowrap so numeric
+   columns don't get ugly mid-number breaks. */
+.ptable .ver-table td{
+  word-break:break-word;
+  overflow-wrap:anywhere;
+}
+.ptable .ver-table td.mono{word-break:normal;overflow-wrap:normal}
 .ptable-boot{
   /* Star glyph for bootable partitions; dot placeholder for the rest
      so the column stays a fixed width even when empty. */


### PR DESCRIPTION
## Summary
- feat(image-scan): parse and display filesystem volume labels — ext / FAT16 / FAT32 / ISO9660 superblocks, surfaced on the partition strip + table
- fix(ui): keep partition table inside its grid track — `.detail-block` was a grid item with default `min-width:auto` and got pushed past the window edge by long unbreakable cells
- ui(queue): align columns via subgrid; ellipsis long filenames — one top-level grid for the queue, rows opt in via `grid-template-columns:subgrid`, filename column is `minmax(0,1fr)` so it never widens the row
- fix(queue): re-kick deep scan for rehydrated rows — `hydrate()` was calling `startValidation` only, so partitions past the validation prefix never got sniffed after a restart
- fix(scan): serve image-partitioned from deep-scan cache when fresh — `inspect_image_partitions` now reads `image_scans` first, preventing the prefix-only re-probe from overwriting the cached deep-scan data
- feat(ui): compact + extended byte formatters; show size in queue row — `formatBytesCompact` (`31.98GB`) on the row meta line, `formatBytesExtended` (`31.98GB (31,000,000,000 bytes)`) on the detail block

## Test plan
- [ ] `npm test`
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`
- [ ] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [ ] Launch on a host with a previously-scanned xz image queued; partitions past the validation prefix should show their real filesystem (`ext4`, `FAT32`) and volume label (`bootfs`, `rootfs`, …) on app start, not the partition-type fallback (`Linux filesystem`)
- [ ] Long filenames in the queue truncate with `…` and don't push `.pstrip` / `.job-detail` past the right edge
