### PR TITLE
fix(updater): show install errors; use localhost for artifact URLs

### DIFF
--- a/scripts/publish-dev-update.sh
+++ b/scripts/publish-dev-update.sh
@@ -22,7 +22,7 @@ cd "$REPO_ROOT"
 source "$REPO_ROOT/scripts/version.sh"
 
 PORT="${PORT:-17780}"
-HOST="${HOST:-127.0.0.1}"
+HOST="${HOST:-localhost}"
 SERVER="https://${HOST}:${PORT}"
 
 KEY_PATH="${TAURI_SIGNING_PRIVATE_KEY_PATH:-$HOME/.diskcutter-updater/updater.key}"

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -1421,6 +1421,7 @@ function UpdatesPanel({ channel, devEndpoint }) {
       await relaunch();
     } catch (e) {
       setError(String(e));
+      setStatus('error');
       setInstalling(false);
     }
   }, [versionEndpoint]);


### PR DESCRIPTION
## Summary
- Show install errors in the UI: set status to \`error\` in the install catch block so the error message renders (was silently swallowed before)
- Default \`HOST\` to \`localhost\` in \`publish-dev-update.sh\` so artifact URLs in generated manifests match the TLS client configuration

## Test plan
- [ ] \`cargo test\`
- [ ] \`cargo clippy --all-targets -- -D warnings\`
- [ ] Publish a dev update and confirm install errors are now visible in the Updates panel