### PR TITLE
ci(diag): capture windows loader error (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,34 @@ jobs:
       - name: cargo clippy --all-targets -- -D warnings
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
+      - name: (diag) capture windows loader error for test exe
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --no-run
+          $exe = Get-ChildItem src-tauri/target/debug/deps/diskcutter_lib-*.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          Write-Host "EXE: $($exe.FullName)"
+          # Run it directly; STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139) surfaces as a
+          # hard error. Capture exit code and any stderr.
+          $out = & $exe.FullName --list 2>&1
+          Write-Host "exit code: $LASTEXITCODE (0x$('{0:X}' -f $LASTEXITCODE))"
+          Write-Host "stdout/stderr:"; $out | ForEach-Object { Write-Host $_ }
+          # The loader's 'entry point X not found in DLL Y' message lands in the
+          # Application event log (Application Error / WER / SideBySide).
+          Write-Host "== recent Application event log =="
+          Get-WinEvent -LogName Application -MaxEvents 30 -ErrorAction SilentlyContinue |
+            Where-Object { $_.Message -match 'entry point|procedure|diskcutter|0xc0000139|could not be located|\.dll' } |
+            ForEach-Object { Write-Host "---`n$($_.TimeCreated) [$($_.ProviderName)]`n$($_.Message)" }
+          # Full import table for offline analysis.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $dumpbin = $null
+          if (Test-Path $vswhere) {
+            $vs = & $vswhere -latest -property installationPath
+            if ($vs) { $dumpbin = (Get-ChildItem "$vs\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue | Select-Object -First 1).FullName }
+          }
+          if ($dumpbin) { Write-Host "== IMPORTS =="; & $dumpbin /IMPORTS $exe.FullName }
+          exit 0
+
       - name: cargo test
         run: cargo test --manifest-path src-tauri/Cargo.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,22 +86,37 @@ jobs:
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
       # TEMP DIAGNOSTIC (remove before merge): the Windows lib-test exe fails to
-      # launch with STATUS_ENTRYPOINT_NOT_FOUND. Dump its imported DLLs/symbols
-      # so we can see which import the runner can't resolve.
-      - name: (diag) Windows test-exe imports
+      # launch with STATUS_ENTRYPOINT_NOT_FOUND. Build main's exe too and diff
+      # the imported symbols to find what this branch newly pulls in.
+      - name: (diag) Windows import delta vs main
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          cargo test --manifest-path src-tauri/Cargo.toml --no-run
-          $exe = Get-ChildItem src-tauri/target/debug/deps/diskcutter_lib-*.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          Write-Host "EXE: $($exe.FullName)"
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $vs = & $vswhere -latest -property installationPath
           $dumpbin = (Get-ChildItem "$vs\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" | Select-Object -First 1).FullName
-          Write-Host "== DEPENDENTS =="
-          & $dumpbin /DEPENDENTS $exe.FullName
-          Write-Host "== IMPORTS (DLL + symbol names) =="
-          & $dumpbin /IMPORTS $exe.FullName | Select-String -Pattern '\.dll|ProcessPrng|GetTempPath2|WaitOnAddress|Bcrypt|Synch|api-ms'
+          function Syms($exe) {
+            (& $dumpbin /IMPORTS $exe) | ForEach-Object {
+              if ($_ -match '^\s+(\S+\.dll)\s*$') { $matches[1].ToLower() }
+              elseif ($_ -match '^\s+[0-9A-Fa-f]+\s+(\S+)\s*$') { $matches[1] }
+            } | Sort-Object -Unique
+          }
+          cargo test --manifest-path src-tauri/Cargo.toml --no-run
+          $mine = (Get-ChildItem src-tauri/target/debug/deps/diskcutter_lib-*.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
+          $minesyms = Syms $mine
+          git fetch --depth=1 origin main
+          git worktree add ../maincheck FETCH_HEAD
+          Push-Location ../maincheck
+          npm ci
+          npm run build
+          cargo test --manifest-path src-tauri/Cargo.toml --no-run
+          $main = (Get-ChildItem src-tauri/target/debug/deps/diskcutter_lib-*.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
+          $mainsyms = Syms $main
+          Pop-Location
+          Write-Host "== imported symbols in THIS BRANCH but NOT in main =="
+          Compare-Object $mainsyms $minesyms | Where-Object { $_.SideIndicator -eq '=>' } | ForEach-Object { $_.InputObject }
+          Write-Host "== imported symbols in main but NOT in this branch =="
+          Compare-Object $mainsyms $minesyms | Where-Object { $_.SideIndicator -eq '<=' } | ForEach-Object { $_.InputObject }
 
       - name: cargo test
         run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,24 @@ jobs:
       - name: cargo clippy --all-targets -- -D warnings
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
+      # TEMP DIAGNOSTIC (remove before merge): the Windows lib-test exe fails to
+      # launch with STATUS_ENTRYPOINT_NOT_FOUND. Dump its imported DLLs/symbols
+      # so we can see which import the runner can't resolve.
+      - name: (diag) Windows test-exe imports
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --no-run
+          $exe = Get-ChildItem src-tauri/target/debug/deps/diskcutter_lib-*.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          Write-Host "EXE: $($exe.FullName)"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -property installationPath
+          $dumpbin = (Get-ChildItem "$vs\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" | Select-Object -First 1).FullName
+          Write-Host "== DEPENDENTS =="
+          & $dumpbin /DEPENDENTS $exe.FullName
+          Write-Host "== IMPORTS (DLL + symbol names) =="
+          & $dumpbin /IMPORTS $exe.FullName | Select-String -Pattern '\.dll|ProcessPrng|GetTempPath2|WaitOnAddress|Bcrypt|Synch|api-ms'
+
       - name: cargo test
         run: cargo test --manifest-path src-tauri/Cargo.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,39 +85,6 @@ jobs:
       - name: cargo clippy --all-targets -- -D warnings
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
-      # TEMP DIAGNOSTIC (remove before merge): the Windows lib-test exe fails to
-      # launch with STATUS_ENTRYPOINT_NOT_FOUND. Build main's exe too and diff
-      # the imported symbols to find what this branch newly pulls in.
-      - name: (diag) Windows import delta vs main
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vs = & $vswhere -latest -property installationPath
-          $dumpbin = (Get-ChildItem "$vs\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" | Select-Object -First 1).FullName
-          function Syms($exe) {
-            (& $dumpbin /IMPORTS $exe) | ForEach-Object {
-              if ($_ -match '^\s+(\S+\.dll)\s*$') { $matches[1].ToLower() }
-              elseif ($_ -match '^\s+[0-9A-Fa-f]+\s+(\S+)\s*$') { $matches[1] }
-            } | Sort-Object -Unique
-          }
-          cargo test --manifest-path src-tauri/Cargo.toml --no-run
-          $mine = (Get-ChildItem src-tauri/target/debug/deps/diskcutter_lib-*.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
-          $minesyms = Syms $mine
-          git fetch --depth=1 origin main
-          git worktree add ../maincheck FETCH_HEAD
-          Push-Location ../maincheck
-          npm ci
-          npm run build
-          cargo test --manifest-path src-tauri/Cargo.toml --no-run
-          $main = (Get-ChildItem src-tauri/target/debug/deps/diskcutter_lib-*.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
-          $mainsyms = Syms $main
-          Pop-Location
-          Write-Host "== imported symbols in THIS BRANCH but NOT in main =="
-          Compare-Object $mainsyms $minesyms | Where-Object { $_.SideIndicator -eq '=>' } | ForEach-Object { $_.InputObject }
-          Write-Host "== imported symbols in main but NOT in this branch =="
-          Compare-Object $mainsyms $minesyms | Where-Object { $_.SideIndicator -eq '<=' } | ForEach-Object { $_.InputObject }
-
       - name: cargo test
         run: cargo test --manifest-path src-tauri/Cargo.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follows [Calendar Versioning](https://calver.org/) (`YYYY.M.D`).
 
 ## [Unreleased]
 
+## [2026.6.2]
+
 ### Added
 
 - **MAKE IMAGE.** New queue row type for imaging a disk to a file. Click
@@ -14,9 +16,23 @@ follows [Calendar Versioning](https://calver.org/) (`YYYY.M.D`).
   speed, and cancel are shown inline alongside burn jobs. The capture
   pipeline runs elevated (osascript) when reading from `/dev/` just like
   the write path.
+- **Guided recovery wizard for an unresponsive disk.** When a disk stops
+  responding, a step-through dialog opens automatically: it names the stuck
+  card when it can (or lists likely candidates when it can't be pinned down),
+  marks which devices are idle-and-safe-to-unplug versus mid-burn, auto-detects
+  the unplug, confirms recovery, and escalates its advice (try the hub, then
+  reboot) if the device stays stuck.
+- Centered **"Loading disks"** panel in the disk pickers — a stepped spinner
+  with a clear label, replacing the small top-left text.
 
 ### Fixed
 
+- **A wedged disk no longer freezes the app.** Disk enumeration shelled out to
+  external tools (`diskutil`/`ps`/`osascript`) synchronously on the UI thread,
+  so an SD card or reader that made `diskutil` hang would freeze the whole
+  window into a blank, unresponsive state. Enumeration now runs off the main
+  thread and every external-tool call is bounded by an 8&nbsp;second timeout — a
+  stuck device produces a brief delay and a partial list instead of a hang.
 - `updates:serve` no longer panics when `dev-updates/` directory does not
   exist — it creates the directory and continues.
 - `updates:publish` no longer commits version bumps for dev iterations;
@@ -337,7 +353,8 @@ mocks.
 - Vitest 2 + happy-dom + React Testing Library for the frontend
   test suite.
 
-[Unreleased]: https://github.com/antimatter-studios/diskcutter/compare/2026.5.28...HEAD
+[Unreleased]: https://github.com/antimatter-studios/diskcutter/compare/2026.6.2...HEAD
+[2026.6.2]: https://github.com/antimatter-studios/diskcutter/compare/2026.5.28...2026.6.2
 [2026.5.28]: https://github.com/antimatter-studios/diskcutter/compare/2026.5.18...2026.5.28
 [2026.5.18]: https://github.com/antimatter-studios/diskcutter/releases/tag/2026.5.18
 [2026.5.12]: https://github.com/antimatter-studios/diskcutter/releases/tag/2026.5.12

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diskcutter",
   "private": true,
-  "version": "2026.5.28-0",
+  "version": "2026.6.2-0",
   "type": "module",
   "author": "Chris Thomas <chris.alex.thomas@gmail.com>",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "diskcutter"
-version = "2026.5.28-0"
+version = "2026.6.2-0"
 dependencies = [
  "am-fs-core",
  "am-img-qcow2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskcutter"
-version = "2026.5.28-0"
+version = "2026.6.2-0"
 description = "Brutalist disk-image writer"
 authors = ["Chris Thomas <chris.alex.thomas@gmail.com>"]
 edition = "2021"

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -442,6 +442,34 @@ pub fn probe_disk_nodes() -> Vec<String> {
     list_dev_whole_disks()
 }
 
+/// Re-run enumeration and report whether it completed without any device
+/// wedging. The recovery wizard calls this after the operator unplugs a card
+/// to decide whether to dismiss itself. Async + bounded for the same reason as
+/// `list_disks`. Also refreshes the last-good cache as a side effect.
+#[tauri::command]
+pub async fn recheck_disks_healthy(app: AppHandle) -> bool {
+    tauri::async_runtime::spawn_blocking(move || {
+        let result = enumerate();
+        update_last_good(&result.disks);
+        // Re-emit so the wizard updates its suspect list if a DIFFERENT device
+        // is still wedged after the unplug.
+        if !result.wedged.is_empty() || result.total_failure {
+            let _ = app.emit(
+                "disk-cutter://device-wedged",
+                DeviceWedged {
+                    devices: result.wedged,
+                    total_failure: result.total_failure,
+                },
+            );
+            false
+        } else {
+            true
+        }
+    })
+    .await
+    .unwrap_or(false)
+}
+
 #[cfg(target_os = "macos")]
 fn list_dev_whole_disks() -> Vec<String> {
     let mut out = Vec::new();

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -252,9 +252,10 @@ pub fn app_info(app: tauri::AppHandle) -> AppInfo {
 /// the PIDs so the frontend can offer to clean them up.
 #[tauri::command]
 pub async fn find_orphan_helpers() -> Vec<u32> {
-    tauri::async_runtime::spawn_blocking(find_orphan_helpers_blocking)
-        .await
-        .unwrap_or_default()
+    // An async command body runs on the async runtime, not the UI thread, so
+    // the blocking `ps` call here can't freeze the window — no need to hop
+    // through async_runtime::spawn_blocking.
+    find_orphan_helpers_blocking()
 }
 
 fn find_orphan_helpers_blocking() -> Vec<u32> {
@@ -298,13 +299,11 @@ fn find_orphan_helpers_blocking() -> Vec<u32> {
 /// Kill orphan helper PIDs via osascript admin (they're root-owned).
 ///
 /// The osascript admin prompt blocks until the user responds to the password
-/// dialog — so this runs on a blocking-pool thread, never the main thread,
-/// or the whole UI would freeze behind the prompt.
+/// dialog. As an async command this body runs on the async runtime, not the
+/// UI thread, so the prompt can't freeze the window.
 #[tauri::command]
 pub async fn kill_orphan_helpers(pids: Vec<u32>) -> Result<(), String> {
-    tauri::async_runtime::spawn_blocking(move || kill_orphan_helpers_blocking(pids))
-        .await
-        .map_err(|e| e.to_string())?
+    kill_orphan_helpers_blocking(pids)
 }
 
 fn kill_orphan_helpers_blocking(pids: Vec<u32>) -> Result<(), String> {
@@ -386,15 +385,13 @@ fn is_privileged() -> bool {
 
 /// Enumerate disks. Shells out to `diskutil`/`lsblk`/`powershell`, any of
 /// which can hang on a wedged device — so this MUST stay off the main thread.
-/// It is `async` and runs the blocking enumeration on a blocking-pool thread;
-/// the tool calls inside are themselves bounded by a timeout. A wedged device
+/// As an `async` command its body runs on the async runtime, not the UI
+/// thread, and the tool calls inside are bounded by a timeout. A wedged device
 /// therefore yields a short delay and a (possibly partial) list, never a
 /// frozen UI.
 #[tauri::command]
 pub async fn list_disks(app: AppHandle) -> Vec<Disk> {
-    tauri::async_runtime::spawn_blocking(move || list_disks_blocking(Some(app)))
-        .await
-        .unwrap_or_default()
+    list_disks_blocking(Some(app))
 }
 
 /// Enumerate, refresh the last-good cache, and — if anything wedged — emit
@@ -452,26 +449,22 @@ pub fn probe_disk_nodes() -> Vec<String> {
 /// `list_disks`. Also refreshes the last-good cache as a side effect.
 #[tauri::command]
 pub async fn recheck_disks_healthy(app: AppHandle) -> bool {
-    tauri::async_runtime::spawn_blocking(move || {
-        let result = enumerate();
-        update_last_good(&result.disks);
-        // Re-emit so the wizard updates its suspect list if a DIFFERENT device
-        // is still wedged after the unplug.
-        if !result.wedged.is_empty() || result.total_failure {
-            let _ = app.emit(
-                "disk-cutter://device-wedged",
-                DeviceWedged {
-                    devices: result.wedged,
-                    total_failure: result.total_failure,
-                },
-            );
-            false
-        } else {
-            true
-        }
-    })
-    .await
-    .unwrap_or(false)
+    let result = enumerate();
+    update_last_good(&result.disks);
+    // Re-emit so the wizard updates its suspect list if a DIFFERENT device
+    // is still wedged after the unplug.
+    if !result.wedged.is_empty() || result.total_failure {
+        let _ = app.emit(
+            "disk-cutter://device-wedged",
+            DeviceWedged {
+                devices: result.wedged,
+                total_failure: result.total_failure,
+            },
+        );
+        false
+    } else {
+        true
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -103,7 +103,9 @@ impl Enumeration {
 static LAST_GOOD_DISKS: Mutex<Vec<Disk>> = Mutex::new(Vec::new());
 
 /// Friendly one-line label for a disk: "MODEL · CAPACITY", trimming whichever
-/// half is missing.
+/// half is missing. Only the macOS wedge path calls this today (and the tests),
+/// so it reads as dead code on other platforms' lib builds.
+#[allow(dead_code)]
 fn friendly_name(d: &Disk) -> String {
     match (d.model.trim(), d.capacity.trim()) {
         ("", "") => d.device.clone(),
@@ -113,7 +115,9 @@ fn friendly_name(d: &Disk) -> String {
     }
 }
 
-/// Look up a device's friendly name from the last good enumeration.
+/// Look up a device's friendly name from the last good enumeration. Only the
+/// macOS wedge path calls this today (and the tests).
+#[allow(dead_code)]
 fn cached_name(device: &str) -> Option<String> {
     let g = LAST_GOOD_DISKS.lock().ok()?;
     g.iter().find(|d| d.device == device).map(friendly_name)
@@ -493,7 +497,7 @@ fn list_dev_whole_disks() -> Vec<String> {
 /// How long to wait on a single external disk-tool invocation before giving up
 /// and killing it. Generous enough for a healthy machine with many disks,
 /// short enough that a wedged device doesn't stall enumeration for long.
-#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "macos")]
 const DISK_TOOL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -55,6 +55,88 @@ pub struct Disk {
     pub flags: Vec<String>,
 }
 
+/// A device the OS disk tool stopped responding for — the input the
+/// "unplug it" recovery wizard reacts to.
+#[derive(Serialize, Clone)]
+pub struct WedgedDevice {
+    /// Device node, e.g. "/dev/disk7".
+    pub device: String,
+    /// Friendly label ("SANDISK ULTRA · 32 GB") recovered from the last good
+    /// enumeration, since we can't probe the device now that it's hung.
+    pub name: Option<String>,
+    /// `true` when this exact device's own probe timed out (high confidence).
+    /// `false` when enumeration as a whole hung and this is only a candidate.
+    pub certain: bool,
+}
+
+/// Emitted on `disk-cutter://device-wedged` whenever enumeration hits a
+/// timeout. The frontend turns this into the guided unplug wizard.
+#[derive(Serialize, Clone)]
+pub struct DeviceWedged {
+    pub devices: Vec<WedgedDevice>,
+    /// `true` when `diskutil list` itself hung, so we never got a device list
+    /// and `devices` are best-effort candidates pulled from /dev nodes.
+    pub total_failure: bool,
+}
+
+/// Result of one enumeration pass: the disks we could read, plus any that
+/// wedged.
+pub struct Enumeration {
+    pub disks: Vec<Disk>,
+    pub wedged: Vec<WedgedDevice>,
+    pub total_failure: bool,
+}
+
+impl Enumeration {
+    fn clean(disks: Vec<Disk>) -> Self {
+        Enumeration {
+            disks,
+            wedged: Vec::new(),
+            total_failure: false,
+        }
+    }
+}
+
+/// Last successful enumeration, keyed implicitly by `Disk::device`. Lets the
+/// wedge detector put a human-readable name on a device whose probe now hangs.
+/// `Mutex::new` + `Vec::new` are const, so no lazy-init crate is needed.
+static LAST_GOOD_DISKS: Mutex<Vec<Disk>> = Mutex::new(Vec::new());
+
+/// Friendly one-line label for a disk: "MODEL · CAPACITY", trimming whichever
+/// half is missing.
+fn friendly_name(d: &Disk) -> String {
+    match (d.model.trim(), d.capacity.trim()) {
+        ("", "") => d.device.clone(),
+        (m, "") => m.to_string(),
+        ("", c) => c.to_string(),
+        (m, c) => format!("{m} · {c}"),
+    }
+}
+
+/// Look up a device's friendly name from the last good enumeration.
+fn cached_name(device: &str) -> Option<String> {
+    let g = LAST_GOOD_DISKS.lock().ok()?;
+    g.iter().find(|d| d.device == device).map(friendly_name)
+}
+
+/// Merge a fresh set of successfully-enumerated disks into the last-good cache.
+/// Updates entries we just saw and keeps prior entries for devices that didn't
+/// appear this pass (e.g. one wedged) so their names stay recoverable.
+fn update_last_good(disks: &[Disk]) {
+    if disks.is_empty() {
+        return;
+    }
+    if let Ok(mut g) = LAST_GOOD_DISKS.lock() {
+        for d in disks {
+            if let Some(slot) = g.iter_mut().find(|c| c.device == d.device) {
+                *slot = d.clone();
+            } else {
+                g.push(d.clone());
+            }
+        }
+    }
+}
+
 #[derive(Serialize, Clone)]
 pub struct JobUpdate {
     pub job_id: i64,
@@ -165,12 +247,17 @@ pub fn app_info(app: tauri::AppHandle) -> AppInfo {
 /// These can hold devices open (esp. /dev/diskN) and block new burns. Returns
 /// the PIDs so the frontend can offer to clean them up.
 #[tauri::command]
-pub fn find_orphan_helpers() -> Vec<u32> {
+pub async fn find_orphan_helpers() -> Vec<u32> {
+    tauri::async_runtime::spawn_blocking(find_orphan_helpers_blocking)
+        .await
+        .unwrap_or_default()
+}
+
+fn find_orphan_helpers_blocking() -> Vec<u32> {
     let me = std::process::id();
-    let out = match std::process::Command::new("ps")
-        .args(["-A", "-o", "pid=,user=,command="])
-        .output()
-    {
+    let mut cmd = std::process::Command::new("ps");
+    cmd.args(["-A", "-o", "pid=,user=,command="]);
+    let out = match crate::proc::output_with_timeout(cmd, std::time::Duration::from_secs(8)) {
         Ok(o) => o,
         Err(_) => return Vec::new(),
     };
@@ -205,8 +292,18 @@ pub fn find_orphan_helpers() -> Vec<u32> {
 }
 
 /// Kill orphan helper PIDs via osascript admin (they're root-owned).
+///
+/// The osascript admin prompt blocks until the user responds to the password
+/// dialog — so this runs on a blocking-pool thread, never the main thread,
+/// or the whole UI would freeze behind the prompt.
 #[tauri::command]
-pub fn kill_orphan_helpers(pids: Vec<u32>) -> Result<(), String> {
+pub async fn kill_orphan_helpers(pids: Vec<u32>) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || kill_orphan_helpers_blocking(pids))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn kill_orphan_helpers_blocking(pids: Vec<u32>) -> Result<(), String> {
     if pids.is_empty() {
         return Ok(());
     }
@@ -283,46 +380,174 @@ fn is_privileged() -> bool {
     }
 }
 
+/// Enumerate disks. Shells out to `diskutil`/`lsblk`/`powershell`, any of
+/// which can hang on a wedged device — so this MUST stay off the main thread.
+/// It is `async` and runs the blocking enumeration on a blocking-pool thread;
+/// the tool calls inside are themselves bounded by a timeout. A wedged device
+/// therefore yields a short delay and a (possibly partial) list, never a
+/// frozen UI.
 #[tauri::command]
-pub fn list_disks() -> Vec<Disk> {
+pub async fn list_disks(app: AppHandle) -> Vec<Disk> {
+    tauri::async_runtime::spawn_blocking(move || list_disks_blocking(Some(app)))
+        .await
+        .unwrap_or_default()
+}
+
+/// Enumerate, refresh the last-good cache, and — if anything wedged — emit
+/// `disk-cutter://device-wedged` so the frontend can launch the unplug wizard.
+/// `app` is `None` only in tests (no event emitted there).
+fn list_disks_blocking(app: Option<AppHandle>) -> Vec<Disk> {
+    let result = enumerate();
+    update_last_good(&result.disks);
+
+    if let Some(app) = app {
+        if !result.wedged.is_empty() || result.total_failure {
+            let _ = app.emit(
+                "disk-cutter://device-wedged",
+                DeviceWedged {
+                    devices: result.wedged,
+                    total_failure: result.total_failure,
+                },
+            );
+        }
+    }
+    result.disks
+}
+
+fn enumerate() -> Enumeration {
     #[cfg(target_os = "macos")]
     {
-        enumerate_macos().unwrap_or_default()
+        enumerate_macos()
     }
     #[cfg(target_os = "linux")]
     {
-        enumerate_linux().unwrap_or_default()
+        Enumeration::clean(enumerate_linux().unwrap_or_default())
     }
     #[cfg(target_os = "windows")]
     {
-        enumerate_windows().unwrap_or_default()
+        Enumeration::clean(enumerate_windows().unwrap_or_default())
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
-        Vec::new()
+        Enumeration::clean(Vec::new())
     }
 }
 
+/// Instant list of whole-disk device nodes straight from `/dev` (a kernel
+/// readdir — it never blocks, even when `diskutil` is wedged). The wizard
+/// polls this while open to notice when the user unplugs something, then
+/// re-runs `list_disks` to confirm recovery.
+#[tauri::command]
+pub fn probe_disk_nodes() -> Vec<String> {
+    list_dev_whole_disks()
+}
+
 #[cfg(target_os = "macos")]
-fn enumerate_macos() -> Option<Vec<Disk>> {
-    use std::process::Command;
-
-    let list = Command::new("diskutil")
-        .args(["list", "-plist"])
-        .output()
-        .ok()?;
-    if !list.status.success() {
-        return None;
-    }
-    let ids = parse_disks_plist(&list.stdout)?;
-
+fn list_dev_whole_disks() -> Vec<String> {
     let mut out = Vec::new();
-    for id in ids {
-        if let Some(d) = info_for_macos(&id) {
-            out.push(d);
+    if let Ok(entries) = std::fs::read_dir("/dev") {
+        for e in entries.flatten() {
+            let name = e.file_name().to_string_lossy().into_owned();
+            if is_whole_disk(&name) {
+                out.push(format!("/dev/{name}"));
+            }
         }
     }
-    Some(out)
+    out.sort();
+    out
+}
+
+#[cfg(not(target_os = "macos"))]
+fn list_dev_whole_disks() -> Vec<String> {
+    Vec::new()
+}
+
+/// How long to wait on a single external disk-tool invocation before giving up
+/// and killing it. Generous enough for a healthy machine with many disks,
+/// short enough that a wedged device doesn't stall enumeration for long.
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+const DISK_TOOL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+
+#[cfg(target_os = "macos")]
+fn enumerate_macos() -> Enumeration {
+    use std::process::Command;
+
+    let mut cmd = Command::new("diskutil");
+    cmd.args(["list", "-plist"]);
+    let list = match crate::proc::output_with_timeout(cmd, DISK_TOOL_TIMEOUT) {
+        Ok(o) if o.status.success() => o,
+        // `diskutil list` itself hung: we have no device list. Fall back to
+        // /dev nodes as unplug candidates and flag total failure.
+        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+            return Enumeration {
+                disks: Vec::new(),
+                wedged: candidate_wedged_from_dev(),
+                total_failure: true,
+            };
+        }
+        // Ran but errored, or spawn failed — not a wedge, just nothing to show.
+        _ => return Enumeration::clean(Vec::new()),
+    };
+    let ids = match parse_disks_plist(&list.stdout) {
+        Some(ids) => ids,
+        None => return Enumeration::clean(Vec::new()),
+    };
+
+    let mut disks = Vec::new();
+    let mut wedged = Vec::new();
+    for id in ids {
+        match info_for_macos(&id) {
+            Ok(Some(d)) => disks.push(d),
+            Ok(None) => {} // info failed cleanly — skip, not a wedge
+            Err(WedgeTimeout) => {
+                let device = format!("/dev/{id}");
+                wedged.push(WedgedDevice {
+                    name: cached_name(&device),
+                    device,
+                    certain: true,
+                });
+            }
+        }
+    }
+    Enumeration {
+        disks,
+        wedged,
+        total_failure: false,
+    }
+}
+
+/// Marker: a per-device `diskutil info` call timed out (the device is wedged),
+/// as distinct from a clean "couldn't parse / not a disk" miss.
+#[cfg(target_os = "macos")]
+struct WedgeTimeout;
+
+/// Whole-disk /dev nodes offered as unplug candidates when enumeration totally
+/// failed. Internal/system disks (per the last-good cache) are excluded so we
+/// never tell the operator to yank their boot drive; nodes unknown to the
+/// cache are kept — a freshly-inserted card is the likeliest culprit.
+#[cfg(target_os = "macos")]
+fn candidate_wedged_from_dev() -> Vec<WedgedDevice> {
+    let cache = LAST_GOOD_DISKS.lock().ok();
+    let mut out = Vec::new();
+    for device in list_dev_whole_disks() {
+        let cached = cache
+            .as_ref()
+            .and_then(|c| c.iter().find(|d| d.device == device));
+        match cached {
+            Some(d) if d.flags.iter().any(|f| f == "INTERNAL") => continue,
+            Some(d) => out.push(WedgedDevice {
+                device,
+                name: Some(friendly_name(d)),
+                certain: false,
+            }),
+            None => out.push(WedgedDevice {
+                device,
+                name: None,
+                certain: false,
+            }),
+        }
+    }
+    out
 }
 
 #[cfg(any(target_os = "macos", test))]
@@ -346,18 +571,18 @@ fn parse_disks_plist(bytes: &[u8]) -> Option<Vec<String>> {
 }
 
 #[cfg(target_os = "macos")]
-fn info_for_macos(id: &str) -> Option<Disk> {
+fn info_for_macos(id: &str) -> Result<Option<Disk>, WedgeTimeout> {
     use std::process::Command;
 
     let path = format!("/dev/{id}");
-    let out = Command::new("diskutil")
-        .args(["info", "-plist", &path])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
+    let mut cmd = Command::new("diskutil");
+    cmd.args(["info", "-plist", &path]);
+    match crate::proc::output_with_timeout(cmd, DISK_TOOL_TIMEOUT) {
+        Ok(out) if out.status.success() => Ok(parse_disk_info_plist(&out.stdout, path)),
+        Ok(_) => Ok(None),
+        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => Err(WedgeTimeout),
+        Err(_) => Ok(None),
     }
-    parse_disk_info_plist(&out.stdout, path)
 }
 
 #[cfg(any(target_os = "macos", test))]
@@ -2626,9 +2851,61 @@ mod tests {
         assert!(verify_image(1).is_ok());
     }
 
+    fn disk(device: &str, model: &str, capacity: &str, flags: &[&str]) -> Disk {
+        Disk {
+            device: device.into(),
+            model: model.into(),
+            capacity: capacity.into(),
+            bytes: 0,
+            bus: "USB".into(),
+            partitions: String::new(),
+            flags: flags.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn friendly_name_joins_model_and_capacity_trimming_blanks() {
+        assert_eq!(
+            friendly_name(&disk("/dev/disk7", "SANDISK ULTRA", "32 GB", &[])),
+            "SANDISK ULTRA · 32 GB"
+        );
+        assert_eq!(
+            friendly_name(&disk("/dev/disk7", "SANDISK", "", &[])),
+            "SANDISK"
+        );
+        assert_eq!(
+            friendly_name(&disk("/dev/disk7", "", "32 GB", &[])),
+            "32 GB"
+        );
+        // Nothing useful → fall back to the device node, never an empty label.
+        assert_eq!(
+            friendly_name(&disk("/dev/disk7", "", "", &[])),
+            "/dev/disk7"
+        );
+    }
+
+    #[test]
+    fn last_good_cache_names_a_device_after_it_drops_out() {
+        // Simulate a good pass that saw disk7, then a pass where it wedged.
+        update_last_good(&[disk(
+            "/dev/diskTEST7",
+            "SANDISK ULTRA",
+            "32 GB",
+            &["REMOVABLE"],
+        )]);
+        assert_eq!(
+            cached_name("/dev/diskTEST7").as_deref(),
+            Some("SANDISK ULTRA · 32 GB")
+        );
+        assert_eq!(cached_name("/dev/diskTEST_absent"), None);
+    }
+
     #[test]
     fn list_disks_returns_without_panic() {
-        let _ = list_disks();
+        // `list_disks` is async (offloads to a blocking thread); exercise the
+        // blocking enumeration directly so the test needs no runtime. `None`
+        // app handle → no event emitted.
+        let _ = list_disks_blocking(None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,8 +41,8 @@ use db::{
 use disks::{
     abort_and_quit, app_info, cancel_capture, cancel_write, check_fda, find_orphan_helpers,
     has_active_burns, inspect_image, kill_orphan_helpers, list_disks, open_fda_settings,
-    probe_disk_nodes, reattach_running_helpers, start_capture, start_write, verify_image,
-    ActiveBurns, CancelRegistry, ElevatedJobs,
+    probe_disk_nodes, reattach_running_helpers, recheck_disks_healthy, start_capture, start_write,
+    verify_image, ActiveBurns, CancelRegistry, ElevatedJobs,
 };
 use std::sync::Mutex;
 use tauri::menu::{AboutMetadataBuilder, MenuBuilder, SubmenuBuilder};
@@ -89,6 +89,7 @@ pub fn run() {
             kill_orphan_helpers,
             list_disks,
             probe_disk_nodes,
+            recheck_disks_healthy,
             inspect_image,
             start_write,
             cancel_write,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod image_scan;
 pub mod inspect;
 pub mod joblog;
 pub mod pipeline;
+pub mod proc;
 pub mod qemu;
 pub mod readers;
 pub mod snapshot;
@@ -40,8 +41,8 @@ use db::{
 use disks::{
     abort_and_quit, app_info, cancel_capture, cancel_write, check_fda, find_orphan_helpers,
     has_active_burns, inspect_image, kill_orphan_helpers, list_disks, open_fda_settings,
-    reattach_running_helpers, start_capture, start_write, verify_image, ActiveBurns,
-    CancelRegistry, ElevatedJobs,
+    probe_disk_nodes, reattach_running_helpers, start_capture, start_write, verify_image,
+    ActiveBurns, CancelRegistry, ElevatedJobs,
 };
 use std::sync::Mutex;
 use tauri::menu::{AboutMetadataBuilder, MenuBuilder, SubmenuBuilder};
@@ -87,6 +88,7 @@ pub fn run() {
             find_orphan_helpers,
             kill_orphan_helpers,
             list_disks,
+            probe_disk_nodes,
             inspect_image,
             start_write,
             cancel_write,

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -6,10 +6,10 @@
 //!     Tauri runs synchronous `#[command] fn`s on the **main thread**, so a
 //!     hung tool there freezes the whole UI — a blank, unresponsive window.
 //!     The fix has two parts that must BOTH hold: commands that shell out are
-//!     `async fn` and offload the blocking work via
-//!     `tauri::async_runtime::spawn_blocking` (keeps the main thread free), and
-//!     the spawn itself runs under [`output_with_timeout`] (so a hung tool
-//!     returns an error instead of pinning a blocking-pool thread forever).
+//!     `async fn` (so their body runs on the async runtime, not the UI thread,
+//!     keeping the window responsive), and each external call runs under
+//!     [`output_with_timeout`] (so a hung tool returns an error instead of
+//!     pinning a runtime thread forever).
 //!
 //!  2. A child that writes more than the pipe buffer holds will block on
 //!     `write` if we don't drain its output. We read stdout/stderr on
@@ -26,8 +26,8 @@ use std::time::{Duration, Instant};
 /// killed and reaped before returning so we don't leak zombies. stdout/stderr
 /// are drained concurrently, so this is safe for tools with large output.
 ///
-/// Intended to be called from inside `spawn_blocking` — it sleeps on the
-/// calling thread, which must never be the main thread.
+/// Sleeps on the calling thread, so call it from an async command body (which
+/// runs on a runtime thread) — never directly on the UI thread.
 pub fn output_with_timeout(mut cmd: Command, timeout: Duration) -> io::Result<Output> {
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -79,7 +79,10 @@ pub fn output_with_timeout(mut cmd: Command, timeout: Duration) -> io::Result<Ou
     })
 }
 
-#[cfg(test)]
+// These tests drive real child processes via unix shell tools
+// (echo/sleep/sh/yes), so they only run on unix. The helper itself is
+// cross-platform std::process and compiles everywhere.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -70,8 +70,18 @@ pub fn output_with_timeout(mut cmd: Command, timeout: Duration) -> io::Result<Ou
         }
     };
 
-    let stdout = rx_out.recv().unwrap_or_default();
-    let stderr = rx_err.recv().unwrap_or_default();
+    // Collect the drained output with a short grace period rather than an
+    // unbounded recv(). The child has exited, so its own pipe write ends are
+    // closed and the drain threads normally hit EOF immediately. But if the
+    // child spawned a grandchild that inherited stdout/stderr, that grandchild
+    // keeps the write end open and the drain thread never sees EOF — an
+    // unbounded recv() would hang here. Bounding it means a pathological
+    // grandchild costs us its captured output, never a stuck call. The drain
+    // threads are detached, so any still-blocked reader exits on its own when
+    // the pipe finally closes.
+    let grace = Duration::from_secs(2);
+    let stdout = rx_out.recv_timeout(grace).unwrap_or_default();
+    let stderr = rx_err.recv_timeout(grace).unwrap_or_default();
     Ok(Output {
         status,
         stdout,

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -1,0 +1,118 @@
+//! Running external tools without ever blocking the main thread.
+//!
+//! Two hazards motivate this module:
+//!
+//!  1. A wedged device can make `diskutil` (and friends) hang indefinitely.
+//!     Tauri runs synchronous `#[command] fn`s on the **main thread**, so a
+//!     hung tool there freezes the whole UI — a blank, unresponsive window.
+//!     The fix has two parts that must BOTH hold: commands that shell out are
+//!     `async fn` and offload the blocking work via
+//!     `tauri::async_runtime::spawn_blocking` (keeps the main thread free), and
+//!     the spawn itself runs under [`output_with_timeout`] (so a hung tool
+//!     returns an error instead of pinning a blocking-pool thread forever).
+//!
+//!  2. A child that writes more than the pipe buffer holds will block on
+//!     `write` if we don't drain its output. We read stdout/stderr on
+//!     dedicated threads so the timeout/kill path can never deadlock.
+
+use std::io;
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+/// Run `cmd` to completion, killing it if it exceeds `timeout`.
+///
+/// Returns `io::ErrorKind::TimedOut` when the deadline elapses; the child is
+/// killed and reaped before returning so we don't leak zombies. stdout/stderr
+/// are drained concurrently, so this is safe for tools with large output.
+///
+/// Intended to be called from inside `spawn_blocking` — it sleeps on the
+/// calling thread, which must never be the main thread.
+pub fn output_with_timeout(mut cmd: Command, timeout: Duration) -> io::Result<Output> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+
+    // Drain both pipes on their own threads so a chatty child can't fill the
+    // pipe buffer and block before exiting (which would look like a hang).
+    let mut stdout = child.stdout.take().expect("stdout piped above");
+    let mut stderr = child.stderr.take().expect("stderr piped above");
+    let (tx_out, rx_out) = mpsc::channel();
+    let (tx_err, rx_err) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = io::Read::read_to_end(&mut stdout, &mut buf);
+        let _ = tx_out.send(buf);
+    });
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = io::Read::read_to_end(&mut stderr, &mut buf);
+        let _ = tx_err.send(buf);
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait()? {
+            Some(status) => break status,
+            None => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("command timed out after {timeout:?}"),
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+
+    let stdout = rx_out.recv().unwrap_or_default();
+    let stderr = rx_err.recv().unwrap_or_default();
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_output_for_fast_command() {
+        let mut c = Command::new("echo");
+        c.arg("hello");
+        let out = output_with_timeout(c, Duration::from_secs(5)).expect("echo runs");
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+    }
+
+    #[test]
+    fn times_out_on_hung_command() {
+        let mut c = Command::new("sleep");
+        c.arg("10");
+        let start = Instant::now();
+        let err = output_with_timeout(c, Duration::from_millis(200)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        // Should return promptly after the timeout, not after the full sleep.
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "killed near deadline"
+        );
+    }
+
+    #[test]
+    fn drains_large_output_without_deadlock() {
+        // ~1 MiB of output, far exceeding the OS pipe buffer.
+        let mut c = Command::new("sh");
+        c.args(["-c", "yes 0123456789 | head -n 100000"]);
+        let out = output_with_timeout(c, Duration::from_secs(10)).expect("completes");
+        assert!(out.status.success());
+        assert!(out.stdout.len() > 1_000_000);
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Disk Cutter",
-  "version": "2026.5.28-0",
+  "version": "2026.6.2-0",
   "identifier": "com.diskcutter.app",
   "build": {
     "beforeBuildCommand": "npm run build",
@@ -27,7 +27,14 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": true,
-    "targets": ["app", "dmg", "deb", "rpm", "appimage", "nsis"],
+    "targets": [
+      "app",
+      "dmg",
+      "deb",
+      "rpm",
+      "appimage",
+      "nsis"
+    ],
     "publisher": "Chris Thomas",
     "icon": [
       "icons/32x32.png",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1151,22 +1151,44 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
   const [recovered, setRecovered] = useState(false);
   const baselineRef = useRef(null); // /dev node set at open / after each check
   const busyRef = useRef(false); // prevents overlapping re-checks
-  const wasOpenRef = useRef(false);
+  const prevSigRef = useRef(null);
   const open = !!state;
 
-  // Fresh open (null -> set): reset transient state and snapshot the current
-  // /dev nodes so we can notice when one disappears.
+  // Identity of the current wedge situation: the set of suspect devices (plus
+  // a total-failure marker). A re-check that re-emits for the SAME stuck device
+  // keeps this signature; a genuinely different device changes it.
+  const sig = state
+    ? (state.total_failure ? 'TF:' : '') + (state.devices || []).map((d) => d.device).sort().join(',')
+    : null;
+
+  // Reset transient state only when the wedge situation actually changes —
+  // a fresh open, or a DIFFERENT device. Crucially we do NOT reset on a
+  // re-emit for the same stuck device (recheck still failing), so escalation
+  // advice keeps progressing instead of snapping back to step 1. Resetting on
+  // a changed situation also clears a stale `recovered` (and, via the effect
+  // below, cancels its pending auto-dismiss) so a newly-wedged device can't be
+  // silently dismissed by the previous device's recovery timer.
   useEffect(() => {
-    if (open && !wasOpenRef.current) {
+    if (!open) { prevSigRef.current = null; return; }
+    if (sig !== prevSigRef.current) {
+      prevSigRef.current = sig;
       setAttempts(0);
       setRecovered(false);
-      baselineRef.current = null;
       invoke('probe_disk_nodes')
         .then((n) => { baselineRef.current = n || []; })
         .catch(() => {});
     }
-    wasOpenRef.current = open;
-  }, [open]);
+  }, [open, sig]);
+
+  // Auto-dismiss shortly after recovery. Driven by an effect (not a bare
+  // setTimeout in recheck) so that if a new wedge arrives within the window —
+  // which flips `recovered` back to false above — the cleanup cancels the
+  // timer instead of dismissing the new alert.
+  useEffect(() => {
+    if (!recovered) return undefined;
+    const id = setTimeout(() => onDismiss(), 1600);
+    return () => clearTimeout(id);
+  }, [recovered, onDismiss]);
 
   const recheck = useCallback(async () => {
     if (busyRef.current) return;
@@ -1177,7 +1199,6 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
       try { baselineRef.current = await invoke('probe_disk_nodes'); } catch { /* keep old baseline */ }
       if (ok) {
         setRecovered(true);
-        setTimeout(() => onDismiss(), 1600);
       } else {
         setAttempts((a) => a + 1);
       }
@@ -1187,7 +1208,7 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
       busyRef.current = false;
       setChecking(false);
     }
-  }, [onDismiss]);
+  }, []);
 
   // While open, poll the instant /dev node list; when something is removed
   // (operator unplugged a device), verify recovery automatically.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,6 +92,10 @@ function App() {
   // Set when the user requests window close while burns are still active.
   // Shape: { active: [{ job_id, target }], phase?: 'cancelling' | 'exiting' }
   const [closeBlocked, setCloseBlocked] = useState(null);
+  // Set when the backend reports a wedged disk device (diskutil/enumeration
+  // timed out). Drives the guided unplug-recovery wizard.
+  // Shape: { devices: [{ device, name, certain }], total_failure }
+  const [wedged, setWedged] = useState(null);
   const [toasts, setToasts] = useState([]);
   const toastIdRef = useRef(0);
   const sessionStartRef = useRef(Date.now());
@@ -297,6 +301,18 @@ function App() {
       if (!mounted) return;
       const phase = e.payload?.phase || null;
       setCloseBlocked((prev) => (prev ? { ...prev, phase } : prev));
+    }).then((u) => subs.push(u));
+
+    // A disk device stopped responding (diskutil/enumeration timed out).
+    // Open the guided unplug wizard so a non-technical operator can recover
+    // without the app having frozen. Re-fires on each failed re-check with the
+    // current suspect list.
+    listen('disk-cutter://device-wedged', (e) => {
+      if (!mounted) return;
+      setWedged({
+        devices: e.payload?.devices || [],
+        total_failure: !!e.payload?.total_failure,
+      });
     }).then((u) => subs.push(u));
 
     return () => {
@@ -697,6 +713,12 @@ function App() {
   // hydrate completes so first paint doesn't flicker between sizes.
   const density = prefs.density || PREFS_DEFAULTS.density;
 
+  // Devices with a burn currently in flight — the wizard tags these
+  // "do NOT unplug" so the operator never yanks a card mid-write.
+  const burningDevices = new Set(
+    jobs.filter((j) => j.state === 'writing' && j.target?.device).map((j) => j.target.device)
+  );
+
   const errorJob = jobs.find((j) => j.state === 'error');
   const errorMsg = errorJob && errorJob.errorCode
     ? (ERROR_CODES.includes(errorJob.errorCode)
@@ -787,6 +809,13 @@ function App() {
         state={closeBlocked}
         accent={accent}
         onCancel={() => setCloseBlocked(null)}
+      />
+
+      <DeviceWedgedWizard
+        state={wedged}
+        accent={accent}
+        burningDevices={burningDevices}
+        onDismiss={() => setWedged(null)}
       />
 
       <ToastLayer toasts={toasts} onDismiss={handleDismissToast} />
@@ -1105,6 +1134,171 @@ function CloseBlockedDialog({ state, accent, onCancel }) {
             {aborting ? t('close_blocked.stopping') : t('close_blocked.abort')}
           </button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// Guided recovery when a disk device stops responding (diskutil/enumeration
+// timed out). The app no longer freezes — instead we walk a (possibly
+// non-technical) operator through unplugging the stuck card, auto-detect the
+// unplug, and confirm recovery. Escalates hub → reboot if re-checks keep
+// failing.
+function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
+  const { t } = useTranslation();
+  const [attempts, setAttempts] = useState(0);
+  const [checking, setChecking] = useState(false);
+  const [recovered, setRecovered] = useState(false);
+  const baselineRef = useRef(null); // /dev node set at open / after each check
+  const busyRef = useRef(false); // prevents overlapping re-checks
+  const wasOpenRef = useRef(false);
+  const open = !!state;
+
+  // Fresh open (null -> set): reset transient state and snapshot the current
+  // /dev nodes so we can notice when one disappears.
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      setAttempts(0);
+      setRecovered(false);
+      baselineRef.current = null;
+      invoke('probe_disk_nodes')
+        .then((n) => { baselineRef.current = n || []; })
+        .catch(() => {});
+    }
+    wasOpenRef.current = open;
+  }, [open]);
+
+  const recheck = useCallback(async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setChecking(true);
+    try {
+      const ok = await invoke('recheck_disks_healthy');
+      try { baselineRef.current = await invoke('probe_disk_nodes'); } catch { /* keep old baseline */ }
+      if (ok) {
+        setRecovered(true);
+        setTimeout(() => onDismiss(), 1600);
+      } else {
+        setAttempts((a) => a + 1);
+      }
+    } catch {
+      setAttempts((a) => a + 1);
+    } finally {
+      busyRef.current = false;
+      setChecking(false);
+    }
+  }, [onDismiss]);
+
+  // While open, poll the instant /dev node list; when something is removed
+  // (operator unplugged a device), verify recovery automatically.
+  useEffect(() => {
+    if (!open || recovered) return undefined;
+    const id = setInterval(async () => {
+      if (busyRef.current) return;
+      let nodes;
+      try { nodes = await invoke('probe_disk_nodes'); } catch { return; }
+      const base = baselineRef.current;
+      if (base && nodes.length < base.length) recheck();
+    }, 1500);
+    return () => clearInterval(id);
+  }, [open, recovered, recheck]);
+
+  if (!state) return null;
+
+  const devices = state.devices || [];
+  const certain = devices.find((d) => d.certain);
+  const stage = attempts >= 4 ? 2 : attempts >= 2 ? 1 : 0;
+
+  const deviceRow = (d) => {
+    const burning = burningDevices?.has(d.device);
+    return (
+      <div key={d.device} className="disk-row" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 0', gap: 12 }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontWeight: 600 }}>{d.name || t('device_wedged.unknown_device')}</div>
+          <div className="mono small" style={{ opacity: 0.6 }}>{d.device}</div>
+        </div>
+        <div className={'status-tag' + (burning ? ' status-tag--danger' : '')} style={{ whiteSpace: 'nowrap' }}>
+          {burning ? t('device_wedged.burning_tag') : t('device_wedged.safe_tag')}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="sheet-backdrop" role="alertdialog" aria-modal="true">
+      <div className="sheet" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 480 }}>
+        <div className="sheet-head">
+          <div>
+            <div className="sheet-eyebrow" style={{ color: accent }}>{t('device_wedged.eyebrow')}</div>
+            <div className="sheet-title">
+              {recovered ? t('device_wedged.recovered_title') : t('device_wedged.title')}
+            </div>
+          </div>
+        </div>
+
+        {recovered ? (
+          <>
+            <div className="sheet-warning" style={{ color: accent }}>
+              <span>✓</span>{t('device_wedged.recovered')}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', padding: 18 }}>
+              <button className="btn" onClick={onDismiss} style={{ background: accent, color: '#fff', borderColor: accent }}>
+                {t('device_wedged.dismiss')}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div style={{ padding: '0 18px', opacity: 0.85 }}>{t('device_wedged.intro')}</div>
+
+            <div className="disk-list" style={{ padding: '12px 18px' }}>
+              {certain ? (
+                <>
+                  <div style={{ fontWeight: 600, marginBottom: 6 }}>{t('device_wedged.suspect_known')}</div>
+                  {deviceRow(certain)}
+                  <div style={{ marginTop: 8 }}>{t('device_wedged.unplug_now')}</div>
+                </>
+              ) : (
+                <>
+                  <div style={{ fontWeight: 600 }}>{t('device_wedged.suspect_unknown_title')}</div>
+                  <div style={{ margin: '6px 0' }}>{t('device_wedged.suspect_unknown')}</div>
+                  {devices.length > 0 && (
+                    <>
+                      <div style={{ fontWeight: 600, marginTop: 8 }}>{t('device_wedged.candidates_label')}</div>
+                      {devices.map(deviceRow)}
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+
+            {stage >= 1 && (
+              <div className="sheet-warning"><span style={{ color: accent }}>⚠</span>{t('device_wedged.step_hub')}</div>
+            )}
+            {stage >= 2 && (
+              <div className="sheet-warning"><span style={{ color: accent }}>⚠</span>{t('device_wedged.step_reboot')}</div>
+            )}
+
+            <div style={{ display: 'flex', gap: 10, padding: 18, justifyContent: 'space-between', alignItems: 'center' }}>
+              <button className="btn btn-ghost" onClick={onDismiss} style={{ opacity: 0.7 }}>
+                {t('device_wedged.handle_myself')}
+              </button>
+              <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                <span className="mono small" style={{ opacity: 0.7 }}>
+                  {checking ? t('device_wedged.checking') : t('device_wedged.waiting')}
+                </span>
+                <button
+                  className="btn"
+                  onClick={recheck}
+                  disabled={checking}
+                  style={{ background: accent, color: '#fff', borderColor: accent }}
+                >
+                  {t('device_wedged.recheck')}
+                </button>
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -1076,6 +1076,22 @@ function SectorMap({ progress, accent }) {
 
 /* ─────────── Disk picker sheet ─────────── */
 
+// Centered loading panel shown in the disk pickers while enumeration runs
+// (now async + bounded, so it can take a beat). Stepped spinner matches the
+// app's other steps() animations.
+function DiskLoading({ accent }) {
+  const { t } = useTranslation();
+  return (
+    <div className="disk-loading">
+      <div className="disk-loading-spinner" style={{ borderTopColor: accent }} aria-hidden="true" />
+      <div className="disk-loading-text">
+        <div className="disk-loading-label">{t('picker.loading', { defaultValue: 'Loading disks' })}</div>
+        <div className="disk-loading-sub">{t('picker.loading_sub', { defaultValue: 'Scanning connected devices' })}</div>
+      </div>
+    </div>
+  );
+}
+
 function DiskPickerSheet({ open, disks, loading, jobImage, onPick, onClose, onRefresh, accent }) {
   const { t } = useTranslation();
   const [refreshedAt, setRefreshedAt] = React.useState(Date.now());
@@ -1114,9 +1130,7 @@ function DiskPickerSheet({ open, disks, loading, jobImage, onPick, onClose, onRe
 
         <div className="disk-list">
           {loading && disks.length === 0 ? (
-            <div className="disk-loading mono small">
-              {t('picker.loading', { defaultValue: 'Loading disks…' })}
-            </div>
+            <DiskLoading accent={accent} />
           ) : (() => {
             const decorated = disks.map((d) => {
               const tooSmall = jobImage && d.bytes < jobImage.bytes;
@@ -2204,9 +2218,9 @@ function CaptureDiskPickerSheet({ open, disks, loading, accent, onPick, onClose 
         </div>
         <div className="disk-list">
           {loading && disks.length === 0 ? (
-            <div className="disk-loading mono small">Loading disks…</div>
+            <DiskLoading accent={accent} />
           ) : disks.length === 0 ? (
-            <div className="disk-loading mono small">No disks found</div>
+            <div className="disk-loading"><div className="disk-loading-empty">{t('picker.empty', { defaultValue: 'No disks found' })}</div></div>
           ) : disks.map((d) => {
             const isInternal = d.bus.includes('NVME') || d.flags?.includes('INTERNAL');
             return (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -268,7 +268,10 @@
     "disks_detected_other": "{{count}} DATENTRÄGER ERKANNT",
     "refresh": "[ R ] AKTUALISIEREN",
     "cancel": "[ ESC ] ABBRECHEN",
-    "refreshed": "VOR {{seconds}}s AKTUALISIERT"
+    "refreshed": "VOR {{seconds}}s AKTUALISIERT",
+    "loading": "Datenträger werden geladen",
+    "loading_sub": "Verbundene Geräte werden gescannt",
+    "empty": "Keine Datenträger gefunden"
   },
   "drag": {
     "drop_here": "ABBILD HIER ABLEGEN"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -513,5 +513,27 @@
       "error": "FEHLER",
       "cancelled": "ABGEBROCHEN"
     }
+  },
+  "device_wedged": {
+    "eyebrow": "GERÄT REAGIERT NICHT",
+    "title": "Ein Datenträger reagiert nicht mehr",
+    "intro": "Eine deiner SD-Karten oder Lesegeräte reagiert nicht mehr. Lass es uns abziehen, damit die App wieder funktioniert – das dauert nur einen Moment.",
+    "suspect_known": "Dieses Gerät reagiert nicht mehr:",
+    "unplug_now": "Zieh es jetzt ab. Die App fährt automatisch fort, sobald es entfernt wurde.",
+    "suspect_unknown_title": "Wir können nicht genau sagen, welches",
+    "suspect_unknown": "Zieh deine Karten oder Lesegeräte einzeln ab – die App meldet sich, sobald sie sich erholt. Beginne mit dem zuletzt eingesteckten.",
+    "candidates_label": "Mögliche Geräte:",
+    "burning_tag": "Wird beschrieben – NICHT abziehen",
+    "safe_tag": "Inaktiv – sicher abziehbar",
+    "unknown_device": "Unbekanntes Gerät",
+    "checking": "Wird geprüft…",
+    "waiting": "Warte, bis du das Gerät abziehst…",
+    "recheck": "[ ABGEZOGEN – ERNEUT PRÜFEN ]",
+    "recovered_title": "Funktioniert wieder",
+    "recovered": "Alle Geräte reagieren wieder. Du kannst weitermachen.",
+    "step_hub": "Immer noch blockiert? Zieh den gesamten USB-Hub oder alle Kartenleser auf einmal ab und prüfe erneut.",
+    "step_reboot": "Wenn es weiterhin hängt, starte deinen Computer neu, um das blockierte Gerät zu lösen.",
+    "dismiss": "[ SCHLIESSEN ]",
+    "handle_myself": "Ich kümmere mich selbst darum"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -268,7 +268,10 @@
     "disks_detected_other": "{{count}} DISKS DETECTED",
     "refresh": "[ R ] REFRESH",
     "cancel": "[ ESC ] CANCEL",
-    "refreshed": "REFRESHED {{seconds}}s AGO"
+    "refreshed": "REFRESHED {{seconds}}s AGO",
+    "loading": "Loading disks",
+    "loading_sub": "Scanning connected devices",
+    "empty": "No disks found"
   },
   "drag": {
     "drop_here": "DROP DISK IMAGE HERE"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -513,5 +513,27 @@
       "error": "ERROR",
       "cancelled": "CANCELLED"
     }
+  },
+  "device_wedged": {
+    "eyebrow": "DEVICE NOT RESPONDING",
+    "title": "A disk stopped responding",
+    "intro": "One of your SD cards or readers has stopped responding. Let’s unplug it so the app works again — it only takes a moment.",
+    "suspect_known": "This device stopped responding:",
+    "unplug_now": "Unplug it now. The app will continue automatically once it’s removed.",
+    "suspect_unknown_title": "We can’t tell exactly which one",
+    "suspect_unknown": "Unplug your cards or readers one at a time — the app will tell you the moment it recovers. Start with the one you inserted most recently.",
+    "candidates_label": "Possible devices:",
+    "burning_tag": "Burning — do NOT unplug",
+    "safe_tag": "Idle — safe to unplug",
+    "unknown_device": "Unknown device",
+    "checking": "Checking…",
+    "waiting": "Waiting for you to unplug the device…",
+    "recheck": "[ I UNPLUGGED IT — CHECK AGAIN ]",
+    "recovered_title": "Working again",
+    "recovered": "All devices are responding. You’re good to go.",
+    "step_hub": "Still stuck? Try unplugging the whole USB hub or all card readers at once, then check again.",
+    "step_reboot": "If it’s still frozen, restart your computer to clear the stuck device.",
+    "dismiss": "[ DISMISS ]",
+    "handle_myself": "I’ll handle it myself"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -513,5 +513,27 @@
       "error": "ERROR",
       "cancelled": "CANCELADO"
     }
+  },
+  "device_wedged": {
+    "eyebrow": "EL DISPOSITIVO NO RESPONDE",
+    "title": "Un disco dejó de responder",
+    "intro": "Una de tus tarjetas SD o lectores dejó de responder. Vamos a desconectarlo para que la app vuelva a funcionar; solo toma un momento.",
+    "suspect_known": "Este dispositivo dejó de responder:",
+    "unplug_now": "Desconéctalo ahora. La app continuará automáticamente cuando lo quites.",
+    "suspect_unknown_title": "No podemos saber exactamente cuál",
+    "suspect_unknown": "Desconecta tus tarjetas o lectores uno por uno; la app te avisará en cuanto se recupere. Empieza por el que insertaste más recientemente.",
+    "candidates_label": "Posibles dispositivos:",
+    "burning_tag": "Grabando: NO desconectar",
+    "safe_tag": "Inactivo: seguro desconectar",
+    "unknown_device": "Dispositivo desconocido",
+    "checking": "Comprobando…",
+    "waiting": "Esperando a que desconectes el dispositivo…",
+    "recheck": "[ LO DESCONECTÉ — COMPROBAR DE NUEVO ]",
+    "recovered_title": "Funciona de nuevo",
+    "recovered": "Todos los dispositivos responden. Ya puedes continuar.",
+    "step_hub": "¿Sigue bloqueado? Prueba a desconectar todo el concentrador USB o todos los lectores a la vez y vuelve a comprobar.",
+    "step_reboot": "Si sigue congelado, reinicia el equipo para liberar el dispositivo bloqueado.",
+    "dismiss": "[ CERRAR ]",
+    "handle_myself": "Lo gestiono yo mismo"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -268,7 +268,10 @@
     "disks_detected_other": "{{count}} DISCOS DETECTADOS",
     "refresh": "[ R ] ACTUALIZAR",
     "cancel": "[ ESC ] CANCELAR",
-    "refreshed": "ACTUALIZADO HACE {{seconds}}s"
+    "refreshed": "ACTUALIZADO HACE {{seconds}}s",
+    "loading": "Cargando discos",
+    "loading_sub": "Analizando dispositivos conectados",
+    "empty": "No se encontraron discos"
   },
   "drag": {
     "drop_here": "SUELTA LA IMAGEN AQUÍ"

--- a/src/styles.css
+++ b/src/styles.css
@@ -844,6 +844,30 @@ input,select{font:inherit;color:inherit}
   display:flex;gap:8px;align-items:center;color:var(--ink);font-weight:600;
 }
 .disk-list{flex:1;overflow:auto}
+.disk-loading{
+  height:100%;min-height:260px;
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  gap:20px;padding:56px 24px;text-align:center;
+}
+.disk-loading-spinner{
+  width:38px;height:38px;
+  border:3px solid rgba(12,12,11,.18);
+  border-top-color:var(--accent,var(--ink));
+  animation:disk-spin .8s steps(8,end) infinite;
+}
+@keyframes disk-spin{to{transform:rotate(1turn)}}
+.disk-loading-text{display:flex;flex-direction:column;gap:7px}
+.disk-loading-label{
+  font-family:var(--mono);font-size:12.5px;letter-spacing:.2em;font-weight:700;
+  text-transform:uppercase;color:var(--ink);
+}
+.disk-loading-sub{
+  font-family:var(--mono);font-size:10.5px;letter-spacing:.06em;color:var(--mute);
+}
+.disk-loading-empty{
+  font-family:var(--mono);font-size:12px;letter-spacing:.1em;font-weight:600;
+  text-transform:uppercase;color:var(--mute);
+}
 .disk{
   width:100%;display:grid;grid-template-columns:42px 1fr auto;gap:14px;align-items:center;
   padding:14px 20px;background:transparent;border:0;border-bottom:1.5px solid rgba(12,12,11,.15);


### PR DESCRIPTION
Diagnostic only. Runs the failing test exe and dumps the loader's missing-entrypoint message + full imports. Will delete.