### PR TITLE
feat(eject): wire auto-eject end-to-end

### DIFF
--- a/src-tauri/src/eject.rs
+++ b/src-tauri/src/eject.rs
@@ -7,12 +7,16 @@
 //! Backends:
 //! - macOS: `diskutil eject <device>` — the only blessed way to
 //!   release a DA-claimed disk.
-//! - Linux: prefer `udisksctl unmount + power-off` (works inside a
-//!   user session), fall back to `eject` (sysvinit-era; widely
-//!   installed; works on many distros without root).
-//! - Windows: not implemented yet — returns an Err so the frontend
-//!   can show "eject not supported on this OS" instead of pretending
-//!   it worked.
+//! - Linux: best-effort `udisksctl unmount` of each partition (the OS
+//!   auto-mounts them from the freshly written image, and `power-off`
+//!   refuses a busy device), then `udisksctl power-off` to release the
+//!   drive — all inside a user session, no root. Falls back to `eject`
+//!   (sysvinit-era; widely installed) if udisksctl is missing or
+//!   power-off still fails.
+//! - Windows: not implemented yet — returns `Ok(EjectOutcome { success:
+//!   false, .. })`, exactly like every other failure here, so the
+//!   frontend's uniform toast path shows "eject not supported on this
+//!   OS". It does not return `Err`.
 //!
 //! Each backend is best-effort: a failure to eject doesn't roll
 //! back the burn, it just surfaces a non-fatal warning.
@@ -121,12 +125,46 @@ fn eject_macos(device: &str) -> EjectOutcome {
     }
 }
 
+/// Best-effort `udisksctl unmount` of every partition on `device`.
+///
+/// `udisksctl power-off` refuses a device with mounted filesystems, and
+/// after a flash the OS auto-mounts any recognisable partitions from the
+/// new image — so without this the primary path fails "busy" and falls
+/// through to `eject` on nearly every Linux session. Partition nodes for a
+/// whole disk live under `/sys/block/<base>/` as sub-entries whose names
+/// start with `<base>` (e.g. `sdb1`, `mmcblk0p1`). Failures (not mounted,
+/// no automount, no udisksctl) are ignored — this only smooths the
+/// happy path; the caller's `eject` fallback still covers the rest.
+#[cfg(target_os = "linux")]
+fn unmount_partitions_udisks(device: &str) {
+    use std::process::Command;
+    let base = match device.rsplit('/').next() {
+        Some(b) if !b.is_empty() => b,
+        _ => return,
+    };
+    let Ok(entries) = std::fs::read_dir(format!("/sys/block/{base}")) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name != base && name.starts_with(base) {
+            let part = format!("/dev/{name}");
+            let _ = Command::new("udisksctl")
+                .args(["unmount", "-b", part.as_str()])
+                .output();
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn eject_linux(device: &str) -> EjectOutcome {
     use std::process::Command;
-    // Prefer udisksctl (no root needed in a user session) — it
-    // unmounts every partition then powers off the drive. Falls back
-    // to the classic `eject` binary if udisksctl is missing.
+    // Prefer udisksctl (no root needed in a user session). The OS
+    // auto-mounts partitions from the freshly written image and
+    // `power-off` refuses a busy device, so unmount each partition first
+    // (best-effort), then power the drive off. Falls back to the classic
+    // `eject` binary if udisksctl is missing or power-off still fails.
+    unmount_partitions_udisks(device);
     if let Ok(out) = Command::new("udisksctl")
         .args(["power-off", "-b", device])
         .output()

--- a/src-tauri/src/eject.rs
+++ b/src-tauri/src/eject.rs
@@ -1,0 +1,230 @@
+//! Eject a previously-burned target so the user can yank the
+//! drive without an "improperly removed" warning. Pairs with the
+//! `auto.eject` preference: the frontend invokes this from its
+//! `job-complete` listener so the workflow is "burn → verify → eject
+//! → user pulls the stick → plug in the next one".
+//!
+//! Backends:
+//! - macOS: `diskutil eject <device>` — the only blessed way to
+//!   release a DA-claimed disk.
+//! - Linux: prefer `udisksctl unmount + power-off` (works inside a
+//!   user session), fall back to `eject` (sysvinit-era; widely
+//!   installed; works on many distros without root).
+//! - Windows: not implemented yet — returns an Err so the frontend
+//!   can show "eject not supported on this OS" instead of pretending
+//!   it worked.
+//!
+//! Each backend is best-effort: a failure to eject doesn't roll
+//! back the burn, it just surfaces a non-fatal warning.
+
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct EjectOutcome {
+    pub success: bool,
+    /// The path we tried to eject, echoed back for the frontend.
+    pub device: String,
+    /// Backend program we invoked (e.g. "diskutil"). Empty when no
+    /// backend ran (unsupported platform).
+    pub backend: String,
+    /// Free-form note: success message or stderr from the failing
+    /// backend.
+    pub note: String,
+}
+
+/// Validate `device` looks like a real device path. We refuse empty
+/// strings and anything containing whitespace or shell metacharacters
+/// — the device path goes straight to a child process, so paranoid
+/// wins. Real Linux/macOS device paths are simple ASCII (`/dev/sdb`,
+/// `/dev/disk5`) and never contain spaces.
+pub fn validate_device(raw: &str) -> Result<&str, &'static str> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return Err("device path is empty");
+    }
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            return Err("device path contains whitespace");
+        }
+        if matches!(ch, ';' | '|' | '&' | '`' | '$' | '(' | ')' | '<' | '>') {
+            return Err("device path contains shell metacharacters");
+        }
+    }
+    if !s.starts_with('/') {
+        return Err("device path must start with '/'");
+    }
+    Ok(s)
+}
+
+#[tauri::command]
+pub fn eject_disk(device: String) -> Result<EjectOutcome, String> {
+    let dev = validate_device(&device).map_err(|e| e.to_string())?;
+    Ok(eject(dev))
+}
+
+/// Plain function entry point. Always returns an `EjectOutcome` —
+/// failures land in `success = false` rather than `Err` so the
+/// frontend can render a uniform toast either way.
+pub fn eject(device: &str) -> EjectOutcome {
+    #[cfg(target_os = "macos")]
+    {
+        eject_macos(device)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        eject_linux(device)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        EjectOutcome {
+            success: false,
+            device: device.to_string(),
+            backend: String::new(),
+            note: "eject not implemented on this platform".to_string(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn eject_macos(device: &str) -> EjectOutcome {
+    use std::process::Command;
+    let out = match Command::new("diskutil").args(["eject", device]).output() {
+        Ok(o) => o,
+        Err(e) => {
+            return EjectOutcome {
+                success: false,
+                device: device.to_string(),
+                backend: "diskutil".into(),
+                note: format!("spawn failed: {e}"),
+            };
+        }
+    };
+    let note = if out.status.success() {
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        format!(
+            "diskutil exited {}: {} {}",
+            out.status,
+            stderr.trim(),
+            stdout.trim()
+        )
+        .trim()
+        .to_string()
+    };
+    EjectOutcome {
+        success: out.status.success(),
+        device: device.to_string(),
+        backend: "diskutil".into(),
+        note,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn eject_linux(device: &str) -> EjectOutcome {
+    use std::process::Command;
+    // Prefer udisksctl (no root needed in a user session) — it
+    // unmounts every partition then powers off the drive. Falls back
+    // to the classic `eject` binary if udisksctl is missing.
+    if let Ok(out) = Command::new("udisksctl")
+        .args(["power-off", "-b", device])
+        .output()
+    {
+        if out.status.success() {
+            return EjectOutcome {
+                success: true,
+                device: device.to_string(),
+                backend: "udisksctl".into(),
+                note: String::from_utf8_lossy(&out.stdout).trim().to_string(),
+            };
+        }
+        // udisksctl was found but failed — try `eject` next.
+    }
+    if let Ok(out) = Command::new("eject").arg(device).output() {
+        return EjectOutcome {
+            success: out.status.success(),
+            device: device.to_string(),
+            backend: "eject".into(),
+            note: if out.status.success() {
+                String::new()
+            } else {
+                String::from_utf8_lossy(&out.stderr).trim().to_string()
+            },
+        };
+    }
+    EjectOutcome {
+        success: false,
+        device: device.to_string(),
+        backend: String::new(),
+        note: "neither udisksctl nor eject is installed".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_device_accepts_typical_paths() {
+        assert!(validate_device("/dev/disk5").is_ok());
+        assert!(validate_device("/dev/sdb").is_ok());
+        assert!(validate_device("/dev/nvme0n1").is_ok());
+    }
+
+    #[test]
+    fn validate_device_trims_whitespace_around() {
+        assert_eq!(validate_device("  /dev/disk5  ").unwrap(), "/dev/disk5");
+    }
+
+    #[test]
+    fn validate_device_rejects_empty() {
+        assert!(validate_device("").is_err());
+        assert!(validate_device("   ").is_err());
+    }
+
+    #[test]
+    fn validate_device_rejects_relative_paths() {
+        assert!(validate_device("disk5").is_err());
+        assert!(validate_device("./dev/disk5").is_err());
+    }
+
+    #[test]
+    fn validate_device_rejects_shell_metacharacters() {
+        for evil in &[
+            "/dev/disk5; rm -rf /",
+            "/dev/disk5 && shutdown",
+            "/dev/disk5|cat",
+            "/dev/disk5`whoami`",
+            "/dev/disk5$(whoami)",
+            "/dev/disk5>file",
+        ] {
+            assert!(validate_device(evil).is_err(), "should reject {evil:?}");
+        }
+    }
+
+    #[test]
+    fn validate_device_rejects_internal_whitespace() {
+        assert!(validate_device("/dev/disk 5").is_err());
+        assert!(validate_device("/dev/disk\t5").is_err());
+    }
+
+    #[test]
+    fn eject_disk_command_rejects_invalid_device() {
+        let r = eject_disk("not-a-path".into());
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn eject_disk_command_returns_outcome_for_valid_path() {
+        // Path is well-formed but device almost certainly doesn't
+        // exist; we expect either success=false (real backend ran
+        // and complained) or success=false (no platform impl). Either
+        // way, no panic and the device echoes back.
+        let r = eject_disk("/dev/disk-cutter-nonexistent-zzzz".into());
+        assert!(r.is_ok());
+        let o = r.unwrap();
+        assert_eq!(o.device, "/dev/disk-cutter-nonexistent-zzzz");
+        assert!(!o.success);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod decoder_chain;
 mod disk_arb;
 mod disks;
 pub mod doctor;
+pub mod eject;
 pub mod forensic;
 pub mod hash;
 mod helper;
@@ -133,6 +134,7 @@ pub fn run() {
             updater::updater_fetch_updates,
             start_capture,
             cancel_capture,
+            eject::eject_disk,
         ])
         .setup(|app| {
             // Persistence is load-bearing: burn_jobs is the source of truth

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,12 +103,19 @@ function App() {
   // round-trip is still pending. Without this, every extra click stacks
   // another osascript prompt + helper.
   const retryInFlightRef = useRef(new Set());
+  // prefs ref so long-lived event listeners can read the latest toggle
+  // (e.g. auto.eject in the job-complete listener) without re-subscribing.
+  const prefsRef = useRef(null);
   const [, forceTick] = useState(0);
 
   useEffect(() => {
     const i = setInterval(() => forceTick((n) => n + 1), 10000);
     return () => clearInterval(i);
   }, []);
+
+  // Keep prefsRef in lockstep with the prefs state — listeners that
+  // mount once but need to observe later pref changes read prefsRef.
+  useEffect(() => { prefsRef.current = prefs; }, [prefs]);
 
   // Push a transient toast. `level` is 'info' | 'warn' | 'error'.
   // Errors linger 8s; info/warn 4s. Stable callback identity so it can be
@@ -192,10 +199,8 @@ function App() {
     if (key === 'language') {
       i18n.changeLanguage(v).catch(() => {});
     }
-    if (key === 'auto.eject' && v === 'true') {
-      // TODO: invoke('eject_disk', { device }) once the backend ships it.
-      console.warn('auto.eject enabled, but eject_disk command is not implemented yet');
-    }
+    // auto.eject pref is consumed at job-complete time (see listener
+    // below); nothing to do at toggle time.
   }, [pushToast, t]);
 
   // Theme: data-theme attribute on <html> drives the dark palette swap.
@@ -259,6 +264,35 @@ function App() {
       },
     });
     subs.push(detachQueue);
+
+    // Auto-eject — sibling job-complete listener that does only the eject
+    // side-effect. The store's own job-complete listener (inside
+    // attachQueueListeners above) handles the queue-state update; this
+    // one just consults the auto.eject pref via ref (so a toggle doesn't
+    // need a re-subscribe), reads the just-completed job's target from
+    // the store, and fires eject_disk when verify matched. Failures
+    // surface as toasts — the burn itself is already done, so a failed
+    // eject is non-blocking.
+    listen('disk-cutter://job-complete', (e) => {
+      if (!mounted) return;
+      if (!e.payload?.verify_match) return;
+      if (prefsRef.current?.['auto.eject'] !== 'true') return;
+      const job = useQueueStore.getState().jobs[e.payload.job_id];
+      const device = job?.target?.device;
+      if (!device) return;
+      invoke('eject_disk', { device })
+        .then((o) => {
+          if (o?.success) {
+            pushToast('info', `Ejected ${device}`);
+          } else {
+            pushToast('warn', `Could not eject ${device}: ${o?.note || ''}`);
+          }
+        })
+        .catch((err) => {
+          console.error('eject_disk failed', err);
+          pushToast('warn', `Eject failed: ${err}`);
+        });
+    }).then((u) => subs.push(u));
 
     // URL fetch: progress as a transient toast every ~250ms; on
     // completion, hand the local file path to addImageFromPath which


### PR DESCRIPTION
## Summary
- **Opt-in auto-eject** (`auto.eject` preference, off by default): after a burn completes **and verify matches**, the just-burned target is ejected so it can be safely pulled and the next card inserted. Targets the bulk-flashing loop: burn → verify → eject → swap card.
- New `eject_disk` Tauri command + `eject` module with per-OS backends:
  - **macOS**: `diskutil eject <device>` (the blessed way to release a DiskArbitration-claimed disk).
  - **Linux**: `udisksctl power-off` (works in a user session, no root), falling back to the classic `eject` binary.
  - **Windows**: not implemented — returns an explicit error so the UI can say "not supported" instead of pretending it worked.
- **Device-path validation** rejects empty/relative paths, whitespace, and shell metacharacters before the path reaches a child process.
- **Best-effort, non-blocking**: a failed eject surfaces a warning toast and never rolls back the completed burn. Outcomes return a uniform `EjectOutcome { success, device, backend, note }`.
- Frontend fires from a dedicated `job-complete` listener gated on `verify_match` and the `auto.eject` pref (read via a ref so toggling the pref doesn't force a re-subscribe).

## Test plan
- [ ] `cargo test` — eject module (device validation + outcome shape)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `npm test`
- [ ] Manual: enable `auto.eject`, burn a card → confirm it ejects on verify-match with an info toast; confirm a failed eject shows a non-blocking warning and the burn stays complete.


## Review feedback addressed

| Reviewer | Path:line | Verdict | Fix |
|---|---|---|---|
| greptile-apps | src-tauri/src/eject.rs:143 | adopt | Linux path now unmounts each partition (enumerated from `/sys/block/<base>/`, run `udisksctl unmount`) before `power-off`, so the primary path no longer fails "busy" and silently falls back to `eject` on auto-mounted devices; module + inline docs corrected to match. Commit b5ca815. |
| greptile-apps | src-tauri/src/eject.rs:14 | adopt | Corrected the Windows backend doc — it returns `Ok(EjectOutcome { success: false })` (the module's uniform toast path), not `Err`. Commit b5ca815. |
