### PR TITLE
fix(ui): stop the wedged-device wizard overflowing its sheet

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1281,7 +1281,7 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
 
   return (
     <div className="sheet-backdrop" role="alertdialog" aria-modal="true">
-      <div className="sheet" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 560, overflowY: 'auto' }}>
+      <div className="sheet" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 560 }}>
         <div className="sheet-head">
           <div>
             <div className="sheet-eyebrow" style={{ color: accent }}>{t('device_wedged.eyebrow')}</div>
@@ -1291,6 +1291,9 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
           </div>
         </div>
 
+        {/* Only the body scrolls; the header (title/eyebrow) stays anchored as
+            an orientation cue when content is tall. */}
+        <div className="sheet-body" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
         {recovered ? (
           <>
             <div className="sheet-warning" style={{ color: accent }}>
@@ -1354,6 +1357,7 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
             </div>
           </>
         )}
+        </div>
       </div>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1281,7 +1281,7 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
 
   return (
     <div className="sheet-backdrop" role="alertdialog" aria-modal="true">
-      <div className="sheet" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 480 }}>
+      <div className="sheet" onClick={(e) => e.stopPropagation()} style={{ maxWidth: 560, overflowY: 'auto' }}>
         <div className="sheet-head">
           <div>
             <div className="sheet-eyebrow" style={{ color: accent }}>{t('device_wedged.eyebrow')}</div>
@@ -1334,14 +1334,14 @@ function DeviceWedgedWizard({ state, accent, burningDevices, onDismiss }) {
               <div className="sheet-warning"><span style={{ color: accent }}>⚠</span>{t('device_wedged.step_reboot')}</div>
             )}
 
-            <div style={{ display: 'flex', gap: 10, padding: 18, justifyContent: 'space-between', alignItems: 'center' }}>
-              <button className="btn btn-ghost" onClick={onDismiss} style={{ opacity: 0.7 }}>
-                {t('device_wedged.handle_myself')}
-              </button>
-              <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                <span className="mono small" style={{ opacity: 0.7 }}>
-                  {checking ? t('device_wedged.checking') : t('device_wedged.waiting')}
-                </span>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: 18 }}>
+              <span className="mono small" style={{ opacity: 0.7 }}>
+                {checking ? t('device_wedged.checking') : t('device_wedged.waiting')}
+              </span>
+              <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', justifyContent: 'space-between', alignItems: 'center' }}>
+                <button className="btn btn-ghost" onClick={onDismiss} style={{ opacity: 0.7 }}>
+                  {t('device_wedged.handle_myself')}
+                </button>
                 <button
                   className="btn"
                   onClick={recheck}


### PR DESCRIPTION
## Summary
The "disk reader has stopped responding" recovery dialog (`DeviceWedgedWizard`) overflowed its container:
- It capped the shared `.sheet` at **480px** (other sheets use 720) and packed the ghost button, the "waiting…/checking…" status, and the long `[ I UNPLUGGED IT — CHECK AGAIN ]` button into a single no-wrap `space-between` row — so text and buttons spilled past the sheet edges.
- The sheet also had no scroll, so tall content (multiple candidate rows + the escalation warnings) clipped.

Fix:
- Widen to **560px** + `overflow-y: auto` so tall content scrolls instead of clipping.
- Move the status text onto its own line and let the action row **wrap** instead of overflowing.

## Test plan
- [ ] `npm run build`
- [ ] Visual: trigger the wedged-device wizard (a disk whose `diskutil` enumeration hangs) and confirm the dialog sits within its sheet — buttons/text no longer overflow, content scrolls if tall, at both the "known device" and "unknown candidates" branches and after escalation (hub/reboot warnings).

Note: layout-only change; not yet verified against a live render (the dialog only appears on a real wedged device).


## Review feedback addressed

| Reviewer | Path:line | Verdict | Fix |
|---|---|---|---|
| greptile-apps | src/App.jsx:1284 | adopt | `overflow-y` on the outer `.sheet` scrolled the header away. Moved scrolling to an inner `.sheet-body` wrapper (`flex:1; min-height:0; overflow-y:auto`); `.sheet-head` stays anchored. Commit 81d5831. |
