### PR TITLE
refactor(cloud): readability pass on the materialize path

### DIFF
--- a/docs/human-code-report-2026-06-10.md
+++ b/docs/human-code-report-2026-06-10.md
@@ -1,0 +1,151 @@
+# Human-code report — 2026-06-10
+
+**Scope:** the cloud-materialize work — `src-tauri/src/cloud.rs` and the
+`spawn_materialize_then_burn` / `begin_burn` paths in `src-tauri/src/disks.rs`.
+
+**Counts:** 6 items found, 6 fixed, 0 skipped. No functional bugs found — these
+are readability/maintainability improvements. All changes are behaviour-
+preserving and guarded by the existing 491-test suite.
+
+---
+
+## Changes made
+
+### H1 — Module doc described the old serial design (comment that lies)
+
+- **File:** [src-tauri/src/cloud.rs](../src-tauri/src/cloud.rs)
+- **What changed:**
+
+  _Before:_
+  ```rust
+  //! ... a single sequential read-through triggers an orderly fault-in ...
+  ```
+  _After:_
+  ```rust
+  //! ... a pool of workers reads every byte (discarding it) to fault the file
+  //! fully in ... The workers pull fixed-size blocks off a shared cursor that
+  //! advances start→end and retry transient provider timeouts ...
+  ```
+- **Why it's better:** the module is the first thing a reader sees, and it was
+  describing a design that no longer exists (the code became a parallel
+  work-queue with retries). The doc now matches the implementation, so a reader
+  isn't actively misled about the core mechanism.
+
+### M1 — `materialize` was a god function
+
+- **File:** [src-tauri/src/cloud.rs](../src-tauri/src/cloud.rs)
+- **What changed:** the ~70-line body that built five `Arc`s, spawned the
+  worker pool inline, ran the monitor loop, joined, and reconciled
+  cancel-vs-error is now orchestration over named pieces:
+  ```rust
+  let state = Arc::new(MaterializeState { cursor, done, stop, live, first_err });
+  let handles = spawn_fault_workers(path, len, workers, &state);
+  run_progress_monitor(&state, &mut on_progress, &should_cancel);
+  for handle in handles { let _ = handle.join(); }
+  ```
+  The five coordination atomics are bundled into a documented `MaterializeState`
+  struct; `spawn_fault_workers` and `run_progress_monitor` hold the thread and
+  loop bodies respectively.
+- **Why it's better:** `materialize` now reads top-to-bottom as "build state →
+  spawn → monitor → join → report," each step a named noun/verb. The struct
+  also names what each atomic is *for* (e.g. `live` = workers still running),
+  which previously a reader had to infer. Bundling them avoids an 8-argument
+  helper.
+
+### L1 — Magic `250` and overflow-coupled shift in the backoff
+
+- **File:** [src-tauri/src/cloud.rs](../src-tauri/src/cloud.rs)
+- **What changed:**
+
+  _Before:_
+  ```rust
+  let backoff = Duration::from_millis(250u64 << (attempt - 1));
+  std::thread::sleep(backoff.min(MATERIALIZE_BACKOFF_CAP));
+  ```
+  _After:_
+  ```rust
+  const MATERIALIZE_BACKOFF_BASE: Duration = Duration::from_millis(250);
+  ...
+  let factor = 1u32.checked_shl(attempt - 1).unwrap_or(u32::MAX);
+  let backoff = MATERIALIZE_BACKOFF_BASE
+      .checked_mul(factor)
+      .unwrap_or(MATERIALIZE_BACKOFF_CAP)
+      .min(MATERIALIZE_BACKOFF_CAP);
+  ```
+- **Why it's better:** the base delay now has a name, and the `checked_*` calls
+  make the exponential growth obviously safe even if `MATERIALIZE_BLOCK_ATTEMPTS`
+  is later raised past the point where `<<` would overflow — the previous form
+  was a latent panic coupled to an unrelated constant.
+
+### M2 — Duplicated config lookup
+
+- **File:** [src-tauri/src/disks.rs](../src-tauri/src/disks.rs)
+- **What changed:** the `try_state::<Db>()` + `SELECT value FROM config WHERE
+  key = ?1` block was copy-pasted in `spawn_materialize_then_burn` and as a
+  closure in `begin_burn`. Both now go through one helper:
+  ```rust
+  fn config_value(app: &AppHandle, key: &str) -> Option<String> { ... }
+  ```
+  `begin_burn`'s local `read_config` closure became a one-line forwarder
+  (`|key| config_value(&app, key)`), so its seven call sites are untouched.
+- **Why it's better:** the SQL and the not-yet-initialised-DB handling live in
+  exactly one place. A change to how config is read (or the query) no longer has
+  to be made in two spots that could drift.
+
+### M3 — `spawn_materialize_then_burn` mixed concerns
+
+- **File:** [src-tauri/src/disks.rs](../src-tauri/src/disks.rs)
+- **What changed:** the inline, stateful progress-throttle closure (tracking
+  `last_emit`/`last_done`, computing the instantaneous rate, emitting) is now a
+  small `MaterializeProgress` reporter:
+  ```rust
+  let mut progress = MaterializeProgress::new(app.clone(), job_id, total);
+  let result = cloud::materialize(&path, workers, |done| progress.report(done), || sentinel.exists());
+  ```
+- **Why it's better:** the spawn function now reads as its actual job
+  (register → emit 0% → resolve workers → materialize → dispatch result) instead
+  of interleaving rate-math and event-throttling. The throttle/rate logic is
+  named and self-contained, with the "why instantaneous, not average" rationale
+  attached to the type.
+
+### L2 — Magic `250` ms progress throttle
+
+- **File:** [src-tauri/src/disks.rs](../src-tauri/src/disks.rs)
+- **What changed:** the bare `Duration::from_millis(250)` throttle interval is
+  now `const PROGRESS_EMIT_INTERVAL`.
+- **Why it's better:** the number has a name explaining what it gates (UI update
+  frequency), separate from the unrelated `250` in cloud.rs's backoff.
+
+---
+
+## Items skipped
+
+None — all six confirmed items were implemented.
+
+| Item | Reason |
+|---|---|
+| — | — |
+
+---
+
+## Test results
+
+| Metric | Before | After |
+|---|---|---|
+| Tests passing | 491 | 491 |
+| Tests failing | 0 | 0 |
+| Baseline tests lost/regressed | — | 0 (`comm -23` empty) |
+| `cargo clippy --all-targets -- -D warnings` | clean | clean |
+
+**Coverage:** preserved by construction — every extraction (M1's helpers, M3's
+`MaterializeProgress`, M2's `config_value`) keeps the same code paths under the
+same callers/tests; no tested code was removed. The cloud.rs paths remain
+covered by the four `cloud::tests::*` unit tests. A separate instrumented
+coverage run was not taken (full-Tauri-crate `llvm-cov` is disproportionately
+slow for a no-behaviour-change refactor, and the test contract already pins the
+behaviour).
+
+**New tests:** none. The new code that wasn't already covered (`config_value`,
+`MaterializeProgress`) is coupled to the Tauri runtime / DB state; unit-testing
+it would require fragile runtime mocking, which the dev-loop guidance says to
+avoid. No new *pure* functions were introduced.

--- a/src-tauri/src/cloud.rs
+++ b/src-tauri/src/cloud.rs
@@ -11,10 +11,13 @@
 //! source was a cloud placeholder.
 //!
 //! We dodge the whole class by materializing the source once, in the parent
-//! (user) process, BEFORE handing the path to the burn helper: a single
-//! sequential read-through triggers an orderly fault-in, so by the time the
-//! helper opens the file the bytes are local and warm. Doing it in the
-//! parent also keeps the download as the invoking user (the File Provider is
+//! (user) process, BEFORE handing the path to the burn helper: a pool of
+//! workers reads every byte (discarding it) to fault the file fully in, so by
+//! the time the helper opens it the bytes are local and warm. The workers pull
+//! fixed-size blocks off a shared cursor that advances start→end and retry
+//! transient provider timeouts, so the download tracks the provider's own
+//! frontier and survives blips (see [`materialize`]). Doing it in the parent
+//! also keeps the download as the invoking user (the File Provider is
 //! per-session) rather than as the elevated root helper.
 
 use std::io::{Read, Seek, SeekFrom};
@@ -69,9 +72,31 @@ const MATERIALIZE_BLOCK: u64 = 8 * 1024 * 1024;
 /// backoff before surfacing the error.
 const MATERIALIZE_BLOCK_ATTEMPTS: u32 = 10;
 
+/// Base delay for the per-block retry backoff; it doubles each attempt up to
+/// [`MATERIALIZE_BACKOFF_CAP`].
+const MATERIALIZE_BACKOFF_BASE: Duration = Duration::from_millis(250);
+
 /// Cap on the per-retry backoff so a genuinely-stuck block doesn't sleep for
 /// a minute on the later attempts (the doubling would otherwise reach ~64s).
 const MATERIALIZE_BACKOFF_CAP: Duration = Duration::from_secs(5);
+
+/// How often the progress monitor polls the shared byte counter while the
+/// worker pool faults the file in.
+const MATERIALIZE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// State the worker pool and the progress monitor coordinate through.
+struct MaterializeState {
+    /// Next block offset to claim; advances start→end.
+    cursor: AtomicU64,
+    /// Bytes faulted in so far (drives progress).
+    done: AtomicU64,
+    /// Set on cancel or the first worker error so the rest wind down.
+    stop: AtomicBool,
+    /// Workers still running; the monitor stops once this reaches zero.
+    live: AtomicUsize,
+    /// First worker error, surfaced by `materialize` after the pool drains.
+    first_err: Mutex<Option<std::io::Error>>,
+}
 
 /// Force a dataless cloud file to fault in by reading every byte (the bytes are
 /// discarded — the goal is purely to make the path resident so the burn's own
@@ -106,52 +131,21 @@ pub fn materialize(
         return Err(cancelled());
     }
 
-    let cursor = Arc::new(AtomicU64::new(0));
-    let done = Arc::new(AtomicU64::new(0));
-    let stop = Arc::new(AtomicBool::new(false));
-    let live = Arc::new(AtomicUsize::new(workers));
-    let first_err: Arc<Mutex<Option<std::io::Error>>> = Arc::new(Mutex::new(None));
+    let state = Arc::new(MaterializeState {
+        cursor: AtomicU64::new(0),
+        done: AtomicU64::new(0),
+        stop: AtomicBool::new(false),
+        live: AtomicUsize::new(workers),
+        first_err: Mutex::new(None),
+    });
 
-    let mut handles = Vec::with_capacity(workers);
-    for _ in 0..workers {
-        let path = path.to_path_buf();
-        let cursor = Arc::clone(&cursor);
-        let done = Arc::clone(&done);
-        let stop = Arc::clone(&stop);
-        let live = Arc::clone(&live);
-        let first_err = Arc::clone(&first_err);
-        handles.push(std::thread::spawn(move || {
-            if let Err(e) = fault_worker(&path, len, &cursor, &done, &stop) {
-                stop.store(true, Ordering::Relaxed);
-                let mut slot = first_err.lock().unwrap();
-                if slot.is_none() {
-                    *slot = Some(e);
-                }
-            }
-            live.fetch_sub(1, Ordering::Relaxed);
-        }));
+    let handles = spawn_fault_workers(path, len, workers, &state);
+    run_progress_monitor(&state, &mut on_progress, &should_cancel);
+    for handle in handles {
+        let _ = handle.join();
     }
 
-    // Monitor from the calling thread: drive progress and honour cancel.
-    // Keeping the loop here means `on_progress` / `should_cancel` stay on this
-    // thread and need no `Send` bound. Stop when every worker has exited (all
-    // blocks faulted, or an error set `stop`).
-    loop {
-        if should_cancel() {
-            stop.store(true, Ordering::Relaxed);
-            break;
-        }
-        on_progress(done.load(Ordering::Relaxed));
-        if live.load(Ordering::Relaxed) == 0 {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    for h in handles {
-        let _ = h.join();
-    }
-
-    if let Some(e) = first_err.lock().unwrap().take() {
+    if let Some(e) = state.first_err.lock().unwrap().take() {
         return Err(e);
     }
     if should_cancel() {
@@ -159,6 +153,56 @@ pub fn materialize(
     }
     on_progress(len);
     Ok(())
+}
+
+/// Spawn `workers` threads that each pull blocks off the shared cursor and
+/// fault them in via [`fault_worker`]. The first worker to fail records its
+/// error and sets `stop` so the rest wind down; every worker decrements `live`
+/// on exit so the monitor can tell when the pool has drained.
+fn spawn_fault_workers(
+    path: &Path,
+    len: u64,
+    workers: usize,
+    state: &Arc<MaterializeState>,
+) -> Vec<std::thread::JoinHandle<()>> {
+    (0..workers)
+        .map(|_| {
+            let path = path.to_path_buf();
+            let state = Arc::clone(state);
+            std::thread::spawn(move || {
+                if let Err(e) = fault_worker(&path, len, &state.cursor, &state.done, &state.stop) {
+                    state.stop.store(true, Ordering::Relaxed);
+                    let mut slot = state.first_err.lock().unwrap();
+                    if slot.is_none() {
+                        *slot = Some(e);
+                    }
+                }
+                state.live.fetch_sub(1, Ordering::Relaxed);
+            })
+        })
+        .collect()
+}
+
+/// Drive `on_progress` from the calling thread until every worker has exited
+/// (all blocks faulted, or an error set `stop`), propagating a cancel request
+/// to the workers via `stop`. Running the loop here keeps `on_progress` /
+/// `should_cancel` off the worker threads, so they need no `Send` bound.
+fn run_progress_monitor(
+    state: &MaterializeState,
+    on_progress: &mut impl FnMut(u64),
+    should_cancel: &impl Fn() -> bool,
+) {
+    loop {
+        if should_cancel() {
+            state.stop.store(true, Ordering::Relaxed);
+            break;
+        }
+        on_progress(state.done.load(Ordering::Relaxed));
+        if state.live.load(Ordering::Relaxed) == 0 {
+            break;
+        }
+        std::thread::sleep(MATERIALIZE_POLL_INTERVAL);
+    }
 }
 
 fn cancelled() -> std::io::Error {
@@ -211,10 +255,16 @@ fn fault_block(
                 if attempt >= MATERIALIZE_BLOCK_ATTEMPTS || stop.load(Ordering::Relaxed) {
                     return Err(e);
                 }
-                // 250ms, 500ms, 1s, 2s, … (capped) — give the provider room to
-                // recover before re-requesting the same range.
-                let backoff = Duration::from_millis(250u64 << (attempt - 1));
-                std::thread::sleep(backoff.min(MATERIALIZE_BACKOFF_CAP));
+                // Exponential backoff (base × 2^(attempt-1)), capped — give the
+                // provider room to recover before re-requesting the same range.
+                // The `checked_*` calls keep this safe even if the attempt cap
+                // is later raised past the point where the shift would overflow.
+                let factor = 1u32.checked_shl(attempt - 1).unwrap_or(u32::MAX);
+                let backoff = MATERIALIZE_BACKOFF_BASE
+                    .checked_mul(factor)
+                    .unwrap_or(MATERIALIZE_BACKOFF_CAP)
+                    .min(MATERIALIZE_BACKOFF_CAP);
+                std::thread::sleep(backoff);
             }
         }
     }

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -1055,6 +1055,64 @@ fn begin_burn(
     Ok(())
 }
 
+/// Read a single value from the `config` table, or `None` if persistence isn't
+/// initialised yet (see lib.rs "continuing without persistence") or the key is
+/// absent. The lookup both `begin_burn` and the materialize path need, in one
+/// place.
+fn config_value(app: &AppHandle, key: &str) -> Option<String> {
+    app.try_state::<Db>().and_then(|db| {
+        let conn = db.0.lock().ok()?;
+        conn.query_row("SELECT value FROM config WHERE key = ?1", [key], |r| {
+            r.get::<_, String>(0)
+        })
+        .ok()
+    })
+}
+
+/// Minimum gap between `materializing` progress events, so a fast local-cache
+/// prefix doesn't flood the UI with updates.
+const PROGRESS_EMIT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Throttled progress reporter for the materialize phase. Emits at most once
+/// per [`PROGRESS_EMIT_INTERVAL`] and reports an *instantaneous* rate (bytes
+/// over the last interval) — a cumulative average lies once a fast local-cache
+/// prefix gives way to the slower network-bound tail.
+struct MaterializeProgress {
+    app: AppHandle,
+    job_id: i64,
+    total: u64,
+    last_emit: std::time::Instant,
+    last_done: u64,
+}
+
+impl MaterializeProgress {
+    fn new(app: AppHandle, job_id: i64, total: u64) -> Self {
+        Self {
+            app,
+            job_id,
+            total,
+            last_emit: std::time::Instant::now(),
+            last_done: 0,
+        }
+    }
+
+    /// Emit a progress event if at least [`PROGRESS_EMIT_INTERVAL`] has elapsed
+    /// since the last one; otherwise do nothing.
+    fn report(&mut self, done: u64) {
+        let dt = self.last_emit.elapsed();
+        if dt < PROGRESS_EMIT_INTERVAL {
+            return;
+        }
+        let bps = (done.saturating_sub(self.last_done) as f64 / dt.as_secs_f64()) as u64;
+        let _ = self.app.emit(
+            "disk-cutter://job-update",
+            make_job_update(self.job_id, "materializing", done, self.total, bps),
+        );
+        self.last_emit = std::time::Instant::now();
+        self.last_done = done;
+    }
+}
+
 /// Download a dataless cloud source to the local cache, emitting a
 /// `materializing` progress phase, then hand off to [`begin_burn`]. Runs on
 /// its own thread (the download can take minutes) so `start_write` returns
@@ -1067,8 +1125,6 @@ fn spawn_materialize_then_burn(
     target_device: String,
     needs_elevation: bool,
 ) {
-    use std::time::{Duration, Instant};
-
     // Clear any stale cancel sentinel from a prior job with this id so we
     // don't insta-cancel the download.
     let _ = std::fs::remove_file(cancel_sentinel_path(&job_id.to_string()));
@@ -1100,41 +1156,15 @@ fn spawn_materialize_then_burn(
         // Worker count is tunable per burn via the `cloud.materialize_workers`
         // config key, so the parallelism sweet spot can be found per
         // provider/link without a rebuild. Falls back to the built-in default.
-        let workers = app
-            .try_state::<Db>()
-            .and_then(|db| {
-                let conn = db.0.lock().ok()?;
-                conn.query_row(
-                    "SELECT value FROM config WHERE key = ?1",
-                    ["cloud.materialize_workers"],
-                    |r| r.get::<_, String>(0),
-                )
-                .ok()
-            })
+        let workers = config_value(&app, "cloud.materialize_workers")
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(cloud::MATERIALIZE_WORKERS);
 
-        let mut last_emit = Instant::now();
-        let mut last_done: u64 = 0;
-        let app_progress = app.clone();
+        let mut progress = MaterializeProgress::new(app.clone(), job_id, total);
         let result = cloud::materialize(
             &path,
             workers,
-            |done| {
-                let dt = last_emit.elapsed();
-                if dt >= Duration::from_millis(250) {
-                    // Instantaneous rate over the last interval — a cumulative
-                    // average lies once a fast local-cache prefix gives way to
-                    // the slower network-bound tail.
-                    let bps = ((done.saturating_sub(last_done)) as f64 / dt.as_secs_f64()) as u64;
-                    let _ = app_progress.emit(
-                        "disk-cutter://job-update",
-                        make_job_update(job_id, "materializing", done, total, bps),
-                    );
-                    last_emit = Instant::now();
-                    last_done = done;
-                }
-            },
+            |done| progress.report(done),
             || sentinel.exists(),
         );
 
@@ -1244,15 +1274,7 @@ fn spawn_elevated_burn_inner(
     // not have been initialised (see lib.rs "continuing without persistence");
     // fall through silently in that case and let the helper apply its own
     // defaults.
-    let read_config = |key: &str| -> Option<String> {
-        app.try_state::<Db>().and_then(|db| {
-            let conn = db.0.lock().ok()?;
-            conn.query_row("SELECT value FROM config WHERE key = ?1", [key], |r| {
-                r.get::<_, String>(0)
-            })
-            .ok()
-        })
-    };
+    let read_config = |key: &str| config_value(&app, key);
     let writer_impl = read_config("writer.impl");
     // Validate numerics by round-tripping through parse(); drop anything we
     // can't interpret so the helper applies its built-in default.


### PR DESCRIPTION
## Summary
Behaviour-preserving readability pass on the cloud-materialize code (from a human-code review). No functional changes — all six items are guarded by the existing **491-test** suite, which still passes, and `clippy -D warnings` is clean.

**cloud.rs**
- Rewrote the module doc — it still described the original *serial* read-through, not the parallel work-queue + retries the code actually became.
- Split the ~70-line `materialize` into a documented `MaterializeState` struct + `spawn_fault_workers` / `run_progress_monitor`, so the top reads as orchestration (build state → spawn → monitor → join → report).
- Named `MATERIALIZE_BACKOFF_BASE` / `MATERIALIZE_POLL_INTERVAL` and made the retry backoff overflow-safe (`checked_shl`/`checked_mul`) instead of a raw `<<` coupled to the attempt cap.

**disks.rs**
- Extracted a shared `config_value(&app, key)` helper (the `try_state` + `SELECT value FROM config` block was duplicated in `begin_burn` and the materialize path).
- Lifted the inline, stateful progress-throttle closure out of `spawn_materialize_then_burn` into a `MaterializeProgress` reporter.
- Named `PROGRESS_EMIT_INTERVAL` for the throttle interval.

Full per-item before/after with rationale: `docs/human-code-report-2026-06-10.md`.

## Test plan
- [ ] `cargo test` (491 tests, unchanged contract)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `npm test`
