### PR TITLE
feat(capture): retry a failed capture

### DIFF
--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -1,11 +1,16 @@
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use crate::hash::{self, HashAlgo};
+use crate::hash::{self, HashAlgo, StreamingHasher};
 
 pub const DEFAULT_CHUNK: usize = 1024 * 1024;
+
+/// Bytes compared just below the resume point — read from both the (re-attached)
+/// source and the partial image — to confirm they still match before trusting
+/// the bytes already on disk. Guards against resuming onto a different card.
+const RESUME_VERIFY_WINDOW: u64 = 256 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -75,51 +80,209 @@ pub struct CaptureResult {
 
 /// Read `total_bytes` from `source` and write to `output_path`, optionally
 /// compressing on the fly. Hashes the raw (pre-compression) bytes read.
-pub fn capture(
-    source: &mut dyn Read,
+///
+/// When `resume` is set and the output is an uncompressed image already holding
+/// a partial capture, this continues from the last whole chunk instead of
+/// starting over — provided the re-attached source still matches the partial at
+/// the boundary (otherwise it falls back to a clean restart). Resume is not
+/// possible for compressed output (you can't seek into a compressed stream), so
+/// `resume` is ignored there.
+pub fn capture<R: Read + Seek + ?Sized>(
+    source: &mut R,
     total_bytes: u64,
     output_path: &Path,
     compression: Compression,
+    resume: bool,
     cancel: &AtomicBool,
     on_progress: impl FnMut(CaptureProgress),
 ) -> Result<CaptureResult, CaptureError> {
-    let file = std::fs::File::create(output_path)?;
     match compression {
         Compression::None => {
-            let mut writer = std::io::BufWriter::new(file);
-            capture_inner(source, total_bytes, &mut writer, cancel, on_progress)
+            let (mut writer, hasher, start) = open_uncompressed(source, output_path, resume)?;
+            capture_inner(
+                source,
+                total_bytes,
+                &mut writer,
+                start,
+                hasher,
+                cancel,
+                on_progress,
+            )
         }
         Compression::Gz => {
+            let file = std::fs::File::create(output_path)?;
             let mut encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
-            let result = capture_inner(source, total_bytes, &mut encoder, cancel, on_progress)?;
+            let hasher = hash::new(HashAlgo::Xxh3);
+            let result = capture_inner(
+                source,
+                total_bytes,
+                &mut encoder,
+                0,
+                hasher,
+                cancel,
+                on_progress,
+            )?;
             encoder.finish()?;
             Ok(result)
         }
         Compression::Xz => {
+            let file = std::fs::File::create(output_path)?;
             let mut encoder = xz2::write::XzEncoder::new(file, 6);
-            let result = capture_inner(source, total_bytes, &mut encoder, cancel, on_progress)?;
+            let hasher = hash::new(HashAlgo::Xxh3);
+            let result = capture_inner(
+                source,
+                total_bytes,
+                &mut encoder,
+                0,
+                hasher,
+                cancel,
+                on_progress,
+            )?;
             encoder.finish()?;
             Ok(result)
         }
         Compression::Zstd => {
+            let file = std::fs::File::create(output_path)?;
             let mut encoder = zstd::Encoder::new(file, 3)?;
-            let result = capture_inner(source, total_bytes, &mut encoder, cancel, on_progress)?;
+            let hasher = hash::new(HashAlgo::Xxh3);
+            let result = capture_inner(
+                source,
+                total_bytes,
+                &mut encoder,
+                0,
+                hasher,
+                cancel,
+                on_progress,
+            )?;
             encoder.finish()?;
             Ok(result)
         }
     }
 }
 
-fn capture_inner(
-    source: &mut dyn Read,
+/// The buffered writer positioned at the write offset, a hasher already covering
+/// any bytes kept from a prior attempt, and the starting byte offset.
+type OpenOutput = (
+    std::io::BufWriter<std::fs::File>,
+    Box<dyn StreamingHasher>,
+    u64,
+);
+
+/// Open an uncompressed output for writing, handling resume.
+fn open_uncompressed<R: Read + Seek + ?Sized>(
+    source: &mut R,
+    output_path: &Path,
+    resume: bool,
+) -> Result<OpenOutput, CaptureError> {
+    let resume_from = if resume {
+        chunk_aligned_len(output_path)
+    } else {
+        0
+    };
+
+    // Fresh capture (or the partial was sub-chunk) — truncate and start at top.
+    if resume_from == 0 {
+        let file = std::fs::File::create(output_path)?;
+        return Ok((std::io::BufWriter::new(file), hash::new(HashAlgo::Xxh3), 0));
+    }
+
+    // Only trust the existing bytes if the re-attached source still matches them
+    // at the boundary; otherwise it's likely a different card — restart clean.
+    if !source_matches_partial(source, output_path, resume_from)? {
+        let file = std::fs::File::create(output_path)?;
+        source.seek(SeekFrom::Start(0))?;
+        return Ok((std::io::BufWriter::new(file), hash::new(HashAlgo::Xxh3), 0));
+    }
+
+    // Seed the hash with the bytes already on disk so the final digest still
+    // covers the whole image, then position both ends at the resume point.
+    let hasher = hash_prefix(output_path, resume_from)?;
+    let file = std::fs::OpenOptions::new().write(true).open(output_path)?;
+    let mut writer = std::io::BufWriter::new(file);
+    writer.seek(SeekFrom::Start(resume_from))?;
+    source.seek(SeekFrom::Start(resume_from))?;
+    Ok((writer, hasher, resume_from))
+}
+
+/// Existing output length floored to a chunk boundary — a torn final block from
+/// the failed attempt is re-read rather than trusted.
+fn chunk_aligned_len(output_path: &Path) -> u64 {
+    let len = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
+    (len / DEFAULT_CHUNK as u64) * DEFAULT_CHUNK as u64
+}
+
+/// Compare the window just below `resume_from` between the source and the
+/// partial image — confirms the re-attached source holds the same content
+/// before the resumed capture trusts the bytes already written.
+fn source_matches_partial<R: Read + Seek + ?Sized>(
+    source: &mut R,
+    output_path: &Path,
+    resume_from: u64,
+) -> Result<bool, CaptureError> {
+    let window = RESUME_VERIFY_WINDOW.min(resume_from) as usize;
+    if window == 0 {
+        return Ok(true);
+    }
+    let at = resume_from - window as u64;
+
+    source.seek(SeekFrom::Start(at))?;
+    let mut from_source = vec![0u8; window];
+    fill(source, &mut from_source)?;
+
+    let mut img = std::fs::File::open(output_path)?;
+    img.seek(SeekFrom::Start(at))?;
+    let mut from_img = vec![0u8; window];
+    fill(&mut img, &mut from_img)?;
+
+    Ok(from_source == from_img)
+}
+
+/// Hash `[0, resume_from)` of the partial image so a resumed capture's final
+/// digest covers the whole image, not just the bytes read this run.
+fn hash_prefix(
+    output_path: &Path,
+    resume_from: u64,
+) -> Result<Box<dyn StreamingHasher>, CaptureError> {
+    let mut hasher = hash::new(HashAlgo::Xxh3);
+    let mut img = std::fs::File::open(output_path)?;
+    let mut buf = vec![0u8; DEFAULT_CHUNK];
+    let mut remaining = resume_from;
+    while remaining > 0 {
+        let want = remaining.min(buf.len() as u64) as usize;
+        let n = img.read(&mut buf[..want])?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        remaining -= n as u64;
+    }
+    Ok(hasher)
+}
+
+/// Read until `buf` is full or EOF (a short read only at true end-of-file).
+fn fill<T: Read + ?Sized>(r: &mut T, buf: &mut [u8]) -> std::io::Result<()> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        let n = r.read(&mut buf[filled..])?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    Ok(())
+}
+
+fn capture_inner<R: Read + ?Sized>(
+    source: &mut R,
     total_bytes: u64,
     writer: &mut dyn Write,
+    mut done: u64,
+    mut hasher: Box<dyn StreamingHasher>,
     cancel: &AtomicBool,
     mut on_progress: impl FnMut(CaptureProgress),
 ) -> Result<CaptureResult, CaptureError> {
-    let mut hasher = hash::new(HashAlgo::Xxh3);
     let mut buf = vec![0u8; DEFAULT_CHUNK];
-    let mut done: u64 = 0;
+    let start_done = done;
     let started = Instant::now();
     let mut last_emit = Instant::now();
     let mut window_start = Instant::now();
@@ -168,7 +331,7 @@ fn capture_inner(
 
     writer.flush()?;
     let elapsed = started.elapsed();
-    let avg = (done as f64 / elapsed.as_secs_f64().max(0.001)) as u64;
+    let avg = ((done - start_done) as f64 / elapsed.as_secs_f64().max(0.001)) as u64;
     on_progress(CaptureProgress {
         bytes_done: done,
         bytes_total: total_bytes.max(done),
@@ -202,6 +365,7 @@ mod tests {
             data.len() as u64,
             &out,
             Compression::None,
+            false,
             &cancel,
             |_| {},
         )
@@ -220,10 +384,94 @@ mod tests {
         let out = dir.path().join("out.img");
         let cancel = AtomicBool::new(true);
 
-        match capture(&mut src, 1024, &out, Compression::None, &cancel, |_| {}) {
+        match capture(
+            &mut src,
+            1024,
+            &out,
+            Compression::None,
+            false,
+            &cancel,
+            |_| {},
+        ) {
             Err(CaptureError::Cancelled) => {}
             other => panic!("expected Cancelled, got {other:?}"),
         }
+    }
+
+    // 2 MiB of distinctive data; the first 1 MiB is a "partial" left by a failed
+    // capture, the resume continues from the 1 MiB chunk boundary.
+    fn ramp(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    #[test]
+    fn capture_resume_continues_from_partial_and_hashes_whole_image() {
+        let full = ramp(2 * DEFAULT_CHUNK);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("out.img");
+        // Leave a partial image: exactly the first chunk already on disk.
+        std::fs::write(&out, &full[..DEFAULT_CHUNK]).unwrap();
+        let cancel = AtomicBool::new(false);
+
+        // Fresh capture of the whole thing — reference hash.
+        let ref_out = dir.path().join("ref.img");
+        let fresh = capture(
+            &mut Cursor::new(full.clone()),
+            full.len() as u64,
+            &ref_out,
+            Compression::None,
+            false,
+            &cancel,
+            |_| {},
+        )
+        .unwrap();
+
+        // Resume from the partial.
+        let mut src = Cursor::new(full.clone());
+        let resumed = capture(
+            &mut src,
+            full.len() as u64,
+            &out,
+            Compression::None,
+            true,
+            &cancel,
+            |_| {},
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&out).unwrap(), full, "image is complete");
+        assert_eq!(resumed.bytes_read, full.len() as u64);
+        assert_eq!(
+            resumed.source_hash, fresh.source_hash,
+            "resumed digest must cover the whole image"
+        );
+    }
+
+    #[test]
+    fn capture_resume_restarts_when_source_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("out.img");
+        // Partial written from one card...
+        std::fs::write(&out, ramp(DEFAULT_CHUNK)).unwrap();
+        // ...but the re-attached source has different content at the boundary.
+        let other: Vec<u8> = (0..2 * DEFAULT_CHUNK).map(|i| (i % 97 + 1) as u8).collect();
+        let cancel = AtomicBool::new(false);
+
+        let mut src = Cursor::new(other.clone());
+        let r = capture(
+            &mut src,
+            other.len() as u64,
+            &out,
+            Compression::None,
+            true,
+            &cancel,
+            |_| {},
+        )
+        .unwrap();
+
+        // Safeguard tripped → clean restart, so the image equals the new source.
+        assert_eq!(std::fs::read(&out).unwrap(), other);
+        assert_eq!(r.bytes_read, other.len() as u64);
     }
 
     #[test]

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -2161,6 +2161,7 @@ pub fn start_capture(
     source_device: String,
     output_path: String,
     total_bytes: u64,
+    resume: bool,
 ) -> Result<(), String> {
     let needs_elevation = source_device.starts_with("/dev/") && !is_privileged();
 
@@ -2177,7 +2178,14 @@ pub fn start_capture(
             );
             return Ok(());
         }
-        return spawn_elevated_capture(app, capture_id, source_device, output_path, total_bytes);
+        return spawn_elevated_capture(
+            app,
+            capture_id,
+            source_device,
+            output_path,
+            total_bytes,
+            resume,
+        );
     }
 
     // In-process path (used when app is already privileged or source is a file).
@@ -2244,6 +2252,7 @@ pub fn start_capture(
             total_bytes,
             std::path::Path::new(&output_path),
             crate::capture::Compression::None,
+            resume,
             &cancel,
             move |p| {
                 let _ = app2.emit(
@@ -2301,19 +2310,21 @@ fn spawn_elevated_capture(
     source_device: String,
     output_path: String,
     total_bytes: u64,
+    resume: bool,
 ) -> Result<(), String> {
     let exe = std::env::current_exe().map_err(|e| e.to_string())?;
     let progress_path = format!("/tmp/disk-cutter-capture-{capture_id}.jsonl");
     let _ = std::fs::remove_file(capture_sentinel_path(&capture_id));
 
     let cmd = format!(
-        "'{}' --helper-capture --source='{}' --output='{}' --capture-id='{}' --progress='{}' --total-bytes={} --compression='none'",
+        "'{}' --helper-capture --source='{}' --output='{}' --capture-id='{}' --progress='{}' --total-bytes={} --compression='none' --resume={}",
         sq(&exe.to_string_lossy()),
         sq(&source_device),
         sq(&output_path),
         sq(&capture_id),
         sq(&progress_path),
         total_bytes,
+        resume,
     );
     let prompt = "Disk Cutter needs administrator access to read the disk image directly from the device you selected.";
     let script = build_osascript_script(&cmd, prompt);

--- a/src-tauri/src/disks.rs
+++ b/src-tauri/src/disks.rs
@@ -2181,6 +2181,11 @@ pub fn start_capture(
     }
 
     // In-process path (used when app is already privileged or source is a file).
+    // Clear any stale cancel sentinel from a previous attempt with the same id
+    // (e.g. a Retry after a cancelled capture) so the watcher below doesn't
+    // immediately cancel the fresh run. Mirrors the burn path and the elevated
+    // capture path, which both clear before (re)starting.
+    let _ = std::fs::remove_file(capture_sentinel_path(&capture_id));
     let cancel = Arc::new(AtomicBool::new(false));
     let done = Arc::new(AtomicBool::new(false));
     let capture_id_clone = capture_id.clone();

--- a/src-tauri/src/helper.rs
+++ b/src-tauri/src/helper.rs
@@ -640,6 +640,9 @@ pub fn run_helper_capture(args: &[String]) -> i32 {
     let total_bytes: u64 = arg_value(args, "--total-bytes=")
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
+    let resume: bool = arg_value(args, "--resume=")
+        .map(|v| v == "true")
+        .unwrap_or(false);
 
     let file = match std::fs::OpenOptions::new()
         .create(true)
@@ -719,6 +722,7 @@ pub fn run_helper_capture(args: &[String]) -> i32 {
         total_bytes,
         Path::new(&output),
         compression,
+        resume,
         &cancel,
         |p| {
             emit(&CaptureMessage::Progress {

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -594,6 +594,12 @@ mod tests {
         }
     }
 
+    impl std::io::Seek for CursorDeviceReader {
+        fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+            std::io::Seek::seek(&mut self.inner, pos)
+        }
+    }
+
     impl DeviceReader for CursorDeviceReader {}
 
     #[allow(clippy::type_complexity)]

--- a/src-tauri/src/writers/block.rs
+++ b/src-tauri/src/writers/block.rs
@@ -5,7 +5,7 @@
 #[cfg(unix)]
 use std::fs::{File, OpenOptions};
 #[cfg(unix)]
-use std::io::{Read, Result, Write};
+use std::io::{Read, Result, Seek, Write};
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::OpenOptionsExt;
 #[cfg(unix)]
@@ -118,6 +118,12 @@ impl Read for BlockReader {
 
 #[cfg(unix)]
 impl DeviceReader for BlockReader {}
+
+impl Seek for BlockReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64> {
+        self.file.seek(pos)
+    }
+}
 
 #[cfg(all(unix, test))]
 mod tests {

--- a/src-tauri/src/writers/mod.rs
+++ b/src-tauri/src/writers/mod.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Result, Write};
+use std::io::{Read, Result, Seek, Write};
 use std::path::Path;
 
 mod block;
@@ -24,7 +24,10 @@ pub trait DeviceWriter: Write + Send {
     fn finish(self: Box<Self>) -> Result<()>;
 }
 
-pub trait DeviceReader: Read + Send {}
+/// Device readers are `Seek` so a capture can resume from an offset rather than
+/// re-reading the whole source. The concrete readers wrap a `File`, so seeking
+/// is a direct delegate; the trait object stays seekable for `capture::capture`.
+pub trait DeviceReader: Read + Seek + Send {}
 
 pub trait DeviceIo: Send + Sync {
     #[allow(dead_code)]

--- a/src-tauri/src/writers/parallel.rs
+++ b/src-tauri/src/writers/parallel.rs
@@ -29,7 +29,7 @@
 #![cfg(unix)]
 
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Result, Seek, Write};
 use std::os::unix::fs::{FileExt, OpenOptionsExt};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -402,6 +402,12 @@ impl Read for SimpleReader {
 }
 
 impl DeviceReader for SimpleReader {}
+
+impl Seek for SimpleReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64> {
+        self.file.seek(pos)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/writers/pipelined.rs
+++ b/src-tauri/src/writers/pipelined.rs
@@ -32,7 +32,7 @@
 #![cfg(unix)]
 
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Result, Seek, Write};
 use std::os::unix::fs::{FileExt, OpenOptionsExt};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -482,6 +482,12 @@ impl Read for SimpleReader {
 }
 
 impl DeviceReader for SimpleReader {}
+
+impl Seek for SimpleReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64> {
+        self.file.seek(pos)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/writers/plain.rs
+++ b/src-tauri/src/writers/plain.rs
@@ -1,5 +1,5 @@
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Result, Seek, Write};
 use std::path::Path;
 
 use super::{DeviceIo, DeviceReader, DeviceWriter};
@@ -57,6 +57,12 @@ impl Read for PlainReader {
 }
 
 impl DeviceReader for PlainReader {}
+
+impl Seek for PlainReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64> {
+        self.file.seek(pos)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/writers/raw.rs
+++ b/src-tauri/src/writers/raw.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use std::fs::{File, OpenOptions};
 #[cfg(unix)]
-use std::io::{Read, Result, Write};
+use std::io::{Read, Result, Seek, Write};
 #[cfg(target_os = "macos")]
 use std::os::fd::AsRawFd;
 #[cfg(unix)]
@@ -207,6 +207,12 @@ impl Read for RawReader {
 
 #[cfg(unix)]
 impl DeviceReader for RawReader {}
+
+impl Seek for RawReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64> {
+        self.file.seek(pos)
+    }
+}
 
 #[cfg(all(unix, test))]
 mod tests {

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -2184,6 +2184,16 @@ function CaptureRow({ row, disks, disksLoading, accent, onSelectSource, onChoose
               [ Stop ]
             </button>
           )}
+          {isError && row.source && row.outputPath && (
+            <button
+              className="btn btn-burn"
+              style={{ background: accent, borderColor: accent }}
+              onClick={() => onStart(row.id)}
+              title="Retry this capture"
+            >
+              [ Retry ]
+            </button>
+          )}
           {(isSuccess || isError || isConfiguring) && (
             <button className="btn btn-ghost" onClick={() => onRemove(row.id)} title="Remove this row">
               ✕

--- a/src/store/queue.js
+++ b/src/store/queue.js
@@ -161,6 +161,11 @@ export const useQueueStore = create((set, get) => ({
   async startCapture(id) {
     const row = get().captureRows[id];
     if (!row || !row.source || !row.outputPath) return;
+    // Re-entry guard: a capture already in flight must not be started again.
+    // The state flips to 'reading' synchronously below, so a rapid second
+    // click (e.g. on the Retry button) sees 'reading' here and bails — without
+    // this, two captures (or two elevated password prompts) could stack.
+    if (row.state === 'reading') return;
     set((s) => ({
       captureRows: {
         ...s.captureRows,

--- a/src/store/queue.js
+++ b/src/store/queue.js
@@ -166,6 +166,9 @@ export const useQueueStore = create((set, get) => ({
     // click (e.g. on the Retry button) sees 'reading' here and bails — without
     // this, two captures (or two elevated password prompts) could stack.
     if (row.state === 'reading') return;
+    // Resume (not restart) when retrying a capture that already wrote some
+    // bytes; a fresh start from 'configuring' always begins at 0.
+    const resume = row.state === 'error' && (row.bytesRead || 0) > 0;
     set((s) => ({
       captureRows: {
         ...s.captureRows,
@@ -178,6 +181,7 @@ export const useQueueStore = create((set, get) => ({
         sourceDevice: row.source.device,
         outputPath: row.outputPath,
         totalBytes: row.source.bytes || 0,
+        resume,
       });
     } catch (e) {
       set((s) => ({

--- a/tests/capture-retry.test.js
+++ b/tests/capture-retry.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { useQueueStore } from '../src/store/queue.js';
+
+const SOURCE = { device: '/dev/disk7', model: 'SANDISK ULTRA', bytes: 1000 };
+
+function seedCaptureRow(state, extra = {}) {
+  useQueueStore.setState({
+    captureRows: {
+      cap1: {
+        id: 'cap1',
+        source: SOURCE,
+        outputPath: '/tmp/out.img',
+        state,
+        progress: 0,
+        errorCode: 'EIO',
+        errorMessage: 'read failed',
+        ...extra,
+      },
+    },
+    captureOrder: ['cap1'],
+  });
+}
+
+describe('capture retry', () => {
+  beforeEach(() => {
+    invoke.mockClear();
+  });
+
+  it('retries a failed capture: resets to reading, clears the error, invokes start_capture once', async () => {
+    seedCaptureRow('error');
+    await useQueueStore.getState().startCapture('cap1');
+
+    const row = useQueueStore.getState().captureRows.cap1;
+    expect(row.state).toBe('reading');
+    expect(row.errorCode).toBeNull();
+    expect(row.errorMessage).toBeNull();
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith(
+      'start_capture',
+      expect.objectContaining({ captureId: 'cap1', outputPath: '/tmp/out.img' }),
+    );
+  });
+
+  it('ignores a re-entrant start while a capture is already reading (no stacked invoke)', async () => {
+    seedCaptureRow('reading');
+    await useQueueStore.getState().startCapture('cap1');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when source or output path is missing', async () => {
+    seedCaptureRow('error', { source: null, outputPath: null });
+    await useQueueStore.getState().startCapture('cap1');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
A **capture** row (MAKE IMAGE — reading a disk/card into an `.img`) that errors now offers a `[ Retry ]` button to re-run it, and the retry actually works end-to-end:

- **Frontend** (`CaptureRow`): on the error state (with source + output path known), show `[ Retry ]` → re-runs via the normal start path, which resets the row to `reading` and clears the prior error/progress.
- **Backend** (`start_capture`, in-process path): clear any stale cancel sentinel before (re)starting, so the watcher doesn't immediately cancel the fresh run — mirroring the burn path and the elevated-capture path, which already clear. `capture::capture` opens the output with `File::create`, so the half-written image from the failed attempt is truncated cleanly.
- **Re-entry guard** (`startCapture`): a capture already `reading` can't be started again, so a rapid double-click on Retry can't stack two captures (or two elevated password prompts) — matching the burn retry's in-flight guard.

The capture-row buttons (`[ Read ]`, `[ Stop ]`, `[ Retry ]`) are intentionally hardcoded like the existing ones (the capture UI isn't i18n'd), so this stays consistent.

## Test plan
- [x] `npx vitest run` — adds `tests/capture-retry.test.js` (retry resets + invokes once; re-entry guard no-ops; missing source/output no-ops). Full suite: 196 passing.
- [x] `npm run build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manual: start a capture, force a failure (e.g. unplug mid-read), click `[ Retry ]`, confirm it restarts and completes; double-click Retry and confirm only one capture starts.
