### PR TITLE
docs(changelog): correct the 2026.5.18 auto-eject entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,9 @@ Linux + Windows builds. macOS bundles are now Developer ID-signed.
 - **Hash benchmark example** (`cargo run --example hash_bench`)
   comparing sha256 vs xxh64 throughput.
 - **Writer benchmark harness** (`cargo run --example writer_bench`).
-- **Auto-eject after a successful burn.**
+- **Auto-eject preference** — the Prefs toggle only. Enabling it logged
+  "not implemented yet"; the backing `eject_disk` command did not land
+  until 2026.7.28.
 - **Real hazard-rim sidebar logo** replacing the placeholder.
 - **Image readers** for `*.gz`, `*.xz`, `*.qcow2` / `*.qcow`. Gzip
   reports the uncompressed size from the ISIZE trailer; XZ sums the


### PR DESCRIPTION
Follow-up to #24. Greptile flagged auto-eject as listed twice; it is, but the
2026.5.18 entry is the wrong one, not the new one.

### The 2026.5.18 entry was never true

`2026.5.18` lists **"Auto-eject after a successful burn."** as a shipped
feature. At that tag only the Prefs toggle existed:

- `git merge-base --is-ancestor 5ff5620 2026.5.18` → **false**
- `git cat-file -e 2026.5.18:src-tauri/src/eject.rs` → **absent**
- `src/App.jsx:192` at that tag:
  ```js
  console.warn('auto.eject enabled, but eject_disk command is not implemented yet');
  ```

The backend landed in `5ff5620`, which shipped in `2026.7.28`.

### Why it looked like it shipped earlier

`5ff5620` has **author date 2026-05-13** but **commit date 2026-06-10** — it was
rebased in about a month after being written. Sorting by author date places it
before the 2026.5.18 tag; ancestry does not. Anything reasoning from author
dates will reach the same wrong conclusion.

### Change

Narrows the 2026.5.18 bullet to the preference toggle that actually shipped and
points at 2026.7.28 for the implementation, so the two mentions read as one
toggle and one implementation rather than a duplicate.

Changelog-only; no code touched.