### PR TITLE
fix(doctor): resolve external tools without executing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ follows [Calendar Versioning](https://calver.org/) (`YYYY.M.D`).
 
 ## [Unreleased]
 
+## [2026.7.29]
+
+### Fixed
+
+- **The QEMU boot test works again when QEMU came from Homebrew.** A
+  Finder-launched app does not inherit your shell's `PATH` — macOS hands
+  it a minimal `/usr/bin:/bin:/usr/sbin:/sbin`, which excludes
+  `/opt/homebrew/bin`. Disk Cutter looked up `qemu-system-*` by bare name
+  against that stripped-down list, so the very QEMU its own error message
+  told you to `brew install` was invisible, and the boot test stayed
+  greyed out no matter what you installed. Tools are now located by
+  searching your login shell's `PATH`, then the process `PATH`, then the
+  usual install prefixes, and are launched by absolute path so detection
+  and execution can't disagree.
+- **Diagnostics no longer report `diskutil` as missing.** The check ran
+  `diskutil --version` and treated a non-zero exit as "not installed",
+  but `diskutil` is verb-based and rejects `--version` outright — so a
+  macOS built-in was reported missing, with a message blaming your `PATH`
+  for it. Auto-eject was never actually affected; only the diagnostic was
+  wrong. Tool detection no longer executes anything to decide whether a
+  tool exists.
+
 ## [2026.7.28]
 
 First published release since 2026.5.28. The 2026.6.2 entries were prepared
@@ -399,7 +421,8 @@ mocks.
 - Vitest 2 + happy-dom + React Testing Library for the frontend
   test suite.
 
-[Unreleased]: https://github.com/antimatter-studios/diskcutter/compare/2026.7.28...HEAD
+[Unreleased]: https://github.com/antimatter-studios/diskcutter/compare/2026.7.29...HEAD
+[2026.7.29]: https://github.com/antimatter-studios/diskcutter/compare/2026.7.28...2026.7.29
 [2026.7.28]: https://github.com/antimatter-studios/diskcutter/compare/2026.5.28...2026.7.28
 [2026.5.28]: https://github.com/antimatter-studios/diskcutter/compare/2026.5.18...2026.5.28
 [2026.5.18]: https://github.com/antimatter-studios/diskcutter/releases/tag/2026.5.18

--- a/src-tauri/src/doctor.rs
+++ b/src-tauri/src/doctor.rs
@@ -102,6 +102,13 @@ pub fn aggregate(checks: &[Check]) -> CheckStatus {
 
 /// Best-effort: return the first line of `<bin> --version` if the
 /// binary is on $PATH and exits 0. None otherwise.
+///
+/// **Not an existence test.** `None` means "did not answer `--version` with
+/// exit 0", which is also what a perfectly present verb-based tool returns —
+/// `diskutil --version` exits 1 with `did not recognize verb`. Using this to
+/// decide whether a tool is installed reported a macOS built-in as missing.
+/// For "is it installed", use [`crate::toolpath::resolve`], which looks
+/// instead of executing and searches beyond the minimal PATH a GUI app gets.
 pub fn probe_binary(bin: &str) -> Option<String> {
     let out = Command::new(bin)
         .arg("--version")
@@ -117,55 +124,60 @@ pub fn probe_binary(bin: &str) -> Option<String> {
     s.lines().next().map(|s| s.trim().to_string())
 }
 
+/// Defers to [`crate::qemu::detect`] rather than probing separately, so the
+/// diagnostic and the feature can never disagree about whether QEMU is
+/// usable — they previously had independent copies of the lookup.
 fn check_qemu() -> Check {
-    if let Some(v) = probe_binary("qemu-system-x86_64") {
+    let found = crate::qemu::detect();
+    if found.available {
         return Check::pass(
             "qemu",
             "QEMU bootability test",
             "feature",
-            &format!("found qemu-system-x86_64: {v}"),
-        );
-    }
-    if let Some(v) = probe_binary("qemu-system-aarch64") {
-        return Check::pass(
-            "qemu",
-            "QEMU bootability test",
-            "feature",
-            &format!("found qemu-system-aarch64: {v}"),
+            &format!("found {}: {}", found.binary, found.version),
         );
     }
     Check::warn(
         "qemu",
         "QEMU bootability test",
         "feature",
-        "qemu-system-* not on PATH — install qemu (brew install qemu / apt install qemu-system) to enable post-burn boot tests",
+        "qemu-system-* not found — install qemu (brew install qemu / apt install qemu-system) to enable post-burn boot tests",
     )
 }
 
 #[cfg(target_os = "macos")]
 fn check_eject_backend() -> Check {
-    if probe_binary("diskutil").is_some() {
-        Check::pass("eject", "Eject backend", "core", "diskutil present")
-    } else {
-        Check::fail(
+    // Existence only. diskutil is verb-based and answers `--version` with
+    // `did not recognize verb` and exit 1, so probing by running it reported
+    // a built-in as missing and then blamed the user's PATH for it.
+    match crate::toolpath::resolve("diskutil") {
+        Some(p) => Check::pass(
+            "eject",
+            "Eject backend",
+            "core",
+            &format!("diskutil present: {}", p.display()),
+        ),
+        None => Check::fail(
             "eject",
             "Eject backend",
             "core",
             "diskutil not found — should be a macOS built-in; PATH may be misconfigured",
-        )
+        ),
     }
 }
 
 #[cfg(target_os = "linux")]
 fn check_eject_backend() -> Check {
-    if probe_binary("udisksctl").is_some() {
+    // Existence only — see the macOS arm for why running the tool is the
+    // wrong existence test.
+    if crate::toolpath::exists("udisksctl") {
         Check::pass(
             "eject",
             "Eject backend",
             "core",
             "udisksctl present (preferred Linux ejector)",
         )
-    } else if probe_binary("eject").is_some() {
+    } else if crate::toolpath::exists("eject") {
         Check::warn(
             "eject",
             "Eject backend",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ pub mod readers;
 pub mod snapshot;
 pub mod source;
 pub mod sparse;
+pub mod toolpath;
 pub mod updater;
 pub mod url_fetch;
 pub mod validate;

--- a/src-tauri/src/qemu.rs
+++ b/src-tauri/src/qemu.rs
@@ -29,9 +29,12 @@ use serde::Serialize;
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct QemuAvailability {
     /// True when at least one of the qemu-system-* binaries we know
-    /// about is present and runnable on $PATH.
+    /// about is present and runnable.
     pub available: bool,
-    /// The first binary name found, e.g. "qemu-system-x86_64".
+    /// Absolute path to the binary found, e.g.
+    /// "/opt/homebrew/bin/qemu-system-x86_64". Absolute rather than a bare
+    /// name so the spawn cannot resolve to something other than what was
+    /// detected — a GUI app's PATH is not the user's PATH.
     pub binary: String,
     /// First-line of `qemu-system-* --version` output, for display.
     pub version: String,
@@ -62,15 +65,26 @@ const QEMU_BINARIES: &[&str] = &[
     "qemu-system-i386",
 ];
 
-/// Detect the first available QEMU binary on `$PATH`. Returns
-/// `available = false` when none are installed; the frontend uses
-/// this to grey out the "boot test" button.
+/// Detect the first available QEMU binary. Returns `available = false` when
+/// none are installed; the frontend uses this to grey out the "boot test"
+/// button.
+///
+/// Resolution goes through [`crate::toolpath`] rather than bare-name lookup:
+/// a Finder-launched `.app` inherits launchd's minimal PATH, which excludes
+/// `/opt/homebrew/bin`, so `brew install qemu` used to leave the feature
+/// permanently greyed out. `binary` is the resolved absolute path, and
+/// [`run_boot_test`] spawns exactly that — detecting one thing and spawning
+/// another is how this stayed broken.
 pub fn detect() -> QemuAvailability {
     for bin in QEMU_BINARIES {
-        if let Some(version) = probe_binary(bin) {
+        let Some(path) = crate::toolpath::resolve(bin) else {
+            continue;
+        };
+        let path = path.to_string_lossy().to_string();
+        if let Some(version) = probe_binary(&path) {
             return QemuAvailability {
                 available: true,
-                binary: bin.to_string(),
+                binary: path,
                 version,
             };
         }

--- a/src-tauri/src/toolpath.rs
+++ b/src-tauri/src/toolpath.rs
@@ -1,0 +1,258 @@
+//! Locating external tool binaries (`qemu-system-*`, `diskutil`,
+//! `udisksctl`, …) from inside a GUI application.
+//!
+//! Two things make this harder than `Command::new("qemu-system-x86_64")`:
+//!
+//! 1. **A Finder-launched `.app` does not inherit your shell's `PATH`.**
+//!    launchd hands it a minimal `/usr/bin:/bin:/usr/sbin:/sbin`, so every
+//!    Homebrew tool is invisible — including the QEMU the app's own error
+//!    message tells you to `brew install`. Running the binary from a terminal
+//!    works, which is exactly why this looks like a phantom bug.
+//!
+//! 2. **`<bin> --version` is not an existence test.** `diskutil` is
+//!    verb-based and answers `did not recognize verb "--version"` with exit 1,
+//!    so probing that way reports a macOS built-in as missing.
+//!
+//! So resolution is separated from version-probing: [`resolve`] answers "where
+//! is it", by *looking* rather than executing, and returns an absolute path.
+//! Callers spawn that path, so detection and execution can never disagree —
+//! the previous code detected by bare name and spawned by bare name, which
+//! meant a passing check still gave you a failing spawn.
+//!
+//! Search order is the user's login-shell `PATH` first (what they'd get in a
+//! terminal, and the most faithful reading of their intent), then the
+//! inherited process `PATH`, then well-known install prefixes. The list is a
+//! union, so a slow or broken login shell degrades to the fallbacks instead of
+//! losing tools.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use crate::proc;
+
+/// A login shell sources the user's rc files, which on a developer machine can
+/// mean version managers, completions, and network-touching prompts. Two
+/// seconds is generous for `printf $PATH` and still well inside the
+/// "diagnostics complete in under a second" budget on the cached path.
+const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Install prefixes to search when `PATH` is the minimal one launchd provides.
+/// Ordered most- to least-likely so the common case exits early.
+#[cfg(target_os = "macos")]
+const FALLBACK_DIRS: &[&str] = &[
+    "/opt/homebrew/bin", // Homebrew, Apple Silicon
+    "/usr/local/bin",    // Homebrew, Intel
+    "/opt/local/bin",    // MacPorts
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+];
+
+#[cfg(target_os = "linux")]
+const FALLBACK_DIRS: &[&str] = &[
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    "/home/linuxbrew/.linuxbrew/bin",
+];
+
+#[cfg(target_os = "windows")]
+const FALLBACK_DIRS: &[&str] = &[];
+
+/// The user's `PATH` as a login shell would see it.
+///
+/// Uses `-lic`: `-l` sources the profile, and `-i` is needed because on macOS
+/// zsh reads `~/.zshrc` — where most people actually set `PATH` — only for
+/// interactive shells. stdin is closed and the call is bounded, so an rc file
+/// that tries to prompt fails fast rather than wedging startup.
+///
+/// `None` when there is no `$SHELL`, the shell errors, or it outruns the
+/// timeout. Callers fall back to the process `PATH` plus [`FALLBACK_DIRS`].
+#[cfg(unix)]
+fn login_shell_path() -> Option<String> {
+    let shell = std::env::var("SHELL").ok()?;
+    if shell.is_empty() {
+        return None;
+    }
+    let mut cmd = Command::new(&shell);
+    cmd.arg("-lic").arg("printf %s \"$PATH\"");
+    let out = proc::output_with_timeout(cmd, LOGIN_SHELL_TIMEOUT).ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // An rc file that prints a banner pollutes stdout ahead of our printf, so
+    // take the last non-empty line rather than the whole buffer.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let path = stdout.lines().rfind(|l| l.contains('/'))?.trim();
+    (!path.is_empty()).then(|| path.to_string())
+}
+
+#[cfg(not(unix))]
+fn login_shell_path() -> Option<String> {
+    None
+}
+
+/// Directories to search, in priority order, deduplicated.
+///
+/// Computed once: the login-shell probe is far too expensive to repeat per
+/// lookup, and `doctor` alone resolves several binaries per run.
+fn search_dirs() -> &'static [PathBuf] {
+    static DIRS: OnceLock<Vec<PathBuf>> = OnceLock::new();
+    DIRS.get_or_init(|| {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+        let mut push = |p: PathBuf| {
+            if !p.as_os_str().is_empty() && !dirs.contains(&p) {
+                dirs.push(p);
+            }
+        };
+
+        if let Some(login) = login_shell_path() {
+            for p in std::env::split_paths(&OsString::from(login)) {
+                push(p);
+            }
+        }
+        if let Some(env_path) = std::env::var_os("PATH") {
+            for p in std::env::split_paths(&env_path) {
+                push(p);
+            }
+        }
+        for d in FALLBACK_DIRS {
+            push(PathBuf::from(d));
+        }
+        dirs
+    })
+}
+
+#[cfg(unix)]
+fn is_executable(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(p: &Path) -> bool {
+    p.is_file()
+}
+
+/// Absolute path to `bin`, or `None` if it isn't installed anywhere we look.
+///
+/// Does not execute anything — a binary that refuses `--version`, prints a
+/// banner, or blocks on stdin still resolves correctly.
+pub fn resolve(bin: &str) -> Option<PathBuf> {
+    // An explicit path is used as given, so a configured absolute path isn't
+    // silently overridden by something earlier on PATH.
+    if bin.contains('/') || bin.contains('\\') {
+        let p = PathBuf::from(bin);
+        return is_executable(&p).then_some(p);
+    }
+
+    for dir in search_dirs() {
+        let candidate = dir.join(bin);
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+        // Windows records the extension in the filename; callers ask for the
+        // bare stem so the same call site works on every platform.
+        #[cfg(target_os = "windows")]
+        for ext in ["exe", "cmd", "bat"] {
+            let c = dir.join(format!("{bin}.{ext}"));
+            if is_executable(&c) {
+                return Some(c);
+            }
+        }
+    }
+    None
+}
+
+/// Whether `bin` is installed. Existence only — see [`resolve`].
+pub fn exists(bin: &str) -> bool {
+    resolve(bin).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_finds_a_universal_binary() {
+        // `sh` is on every unix in a standard location.
+        #[cfg(unix)]
+        assert!(resolve("sh").is_some(), "sh should resolve on any unix");
+    }
+
+    #[test]
+    fn resolve_returns_none_for_a_missing_binary() {
+        assert!(resolve("disk-cutter-no-such-binary-abc123").is_none());
+    }
+
+    #[test]
+    fn resolved_paths_are_absolute_and_executable() {
+        #[cfg(unix)]
+        {
+            let p = resolve("sh").expect("sh resolves");
+            assert!(p.is_absolute(), "callers spawn this path directly");
+            assert!(is_executable(&p));
+        }
+    }
+
+    /// The bug this module exists for: `diskutil` is a macOS built-in, but it
+    /// has no `--version` verb and exits non-zero when handed one. Resolving
+    /// by execution reported it missing and blamed the user's PATH.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn diskutil_resolves_even_though_it_rejects_version_flag() {
+        assert!(
+            exists("diskutil"),
+            "diskutil is a macOS built-in and must always resolve"
+        );
+
+        let rejects_version_flag = Command::new("diskutil")
+            .arg("--version")
+            .output()
+            .map(|o| !o.status.success())
+            .unwrap_or(false);
+        assert!(
+            rejects_version_flag,
+            "if diskutil ever gains --version this test is obsolete, but \
+             resolution must still not depend on it"
+        );
+    }
+
+    #[test]
+    fn an_explicit_path_is_honoured() {
+        #[cfg(unix)]
+        {
+            assert_eq!(resolve("/bin/sh"), Some(PathBuf::from("/bin/sh")));
+            assert!(resolve("/bin/definitely-not-here-xyz").is_none());
+        }
+    }
+
+    #[test]
+    fn search_dirs_are_deduplicated() {
+        let dirs = search_dirs();
+        let mut seen = std::collections::HashSet::new();
+        for d in dirs {
+            assert!(seen.insert(d), "duplicate search dir: {}", d.display());
+        }
+    }
+
+    #[test]
+    fn search_dirs_include_the_fallbacks() {
+        let dirs = search_dirs();
+        for d in FALLBACK_DIRS {
+            let want = PathBuf::from(d);
+            assert!(
+                dirs.contains(&want),
+                "fallback {d} missing — a minimal launchd PATH would lose it"
+            );
+        }
+    }
+}

--- a/src-tauri/src/toolpath.rs
+++ b/src-tauri/src/toolpath.rs
@@ -27,16 +27,23 @@
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::OnceLock;
+
+// Only the unix arm shells out to read the login PATH; on Windows these would
+// be unused imports, and CI runs clippy with -D warnings on every platform.
+#[cfg(unix)]
+use std::process::Command;
+#[cfg(unix)]
 use std::time::Duration;
 
+#[cfg(unix)]
 use crate::proc;
 
 /// A login shell sources the user's rc files, which on a developer machine can
 /// mean version managers, completions, and network-touching prompts. Two
 /// seconds is generous for `printf $PATH` and still well inside the
 /// "diagnostics complete in under a second" budget on the cached path.
+#[cfg(unix)]
 const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Install prefixes to search when `PATH` is the minimal one launchd provides.


### PR DESCRIPTION
Two diagnostics reported present tools as missing. Different causes, one fix.

### 1. `diskutil not found — PATH may be misconfigured`

`probe_binary` tested existence by running `<bin> --version` and requiring exit 0:

```
$ /usr/sbin/diskutil --version
diskutil: did not recognize verb "--version"; type "diskutil" for a list
$ echo $?
1
```

`diskutil` is verb-based and has no `--version`. So a macOS built-in sitting at
`/usr/sbin/diskutil` was reported missing, and the message then blamed the
user's PATH — sending them to debug a non-problem.

Cosmetic only: `eject.rs` invokes `diskutil` directly, so auto-eject worked.

### 2. `qemu-system-* not on PATH` when it demonstrably is

A Finder-launched `.app` does **not** inherit your shell PATH. launchd hands it
`/usr/bin:/bin:/usr/sbin:/sbin`, which excludes `/opt/homebrew/bin`. The app
tells you to `brew install qemu` and then cannot see what brew installed.

**Not cosmetic.** `detect()` and `run_boot_test()` both resolved by bare name,
so the boot test was genuinely unavailable to every Homebrew install.

This also explains why `diskutil` was the only casualty of bug 1 — `/usr/sbin`
*is* in the launchd default.

### Fix

New `toolpath` module that resolves by **looking rather than executing**, and
returns an **absolute path** callers spawn directly. Detecting by name and
spawning by name is precisely what let a passing check coexist with a failing
spawn.

Search order, as a union so nothing is lost:

1. Login-shell PATH — `$SHELL -lic`. `-i` is required because macOS zsh reads
   `~/.zshrc`, where most PATH entries live, only for interactive shells.
2. Inherited process PATH.
3. Known prefixes — `/opt/homebrew/bin`, `/usr/local/bin`, `/opt/local/bin`, …

Bounded at 2s with stdin closed, cached in a `OnceLock`. `doctor` states its
checks must finish "well under a second"; only the first lookup pays, and a
slow or hostile rc file degrades to the fallbacks rather than wedging startup.

`doctor::check_qemu` now defers to `qemu::detect()` instead of keeping a second
copy of the lookup, so the diagnostic and the feature cannot drift apart.

### Verification

Under a simulated launchd PATH (`/usr/bin:/bin:/usr/sbin:/sbin`):

```
--- OLD (probe via --version, bare name) ---
  diskutil:           reported MISSING
  qemu-system-x86_64: reported MISSING

--- NEW (look, don't execute; search fallback prefixes) ---
  diskutil:           FOUND at /usr/sbin/diskutil
  qemu-system-x86_64: FOUND at /opt/homebrew/bin/qemu-system-x86_64
```

7 new tests, including a regression test pinning the actual defect — that
`diskutil` rejects `--version` — so nobody reintroduces the assumption.

### Left for a follow-up

`probe_binary` is now unused by production code but kept for qemu's version
string, with a doc note that it is **not** an existence test. Its two tests are
untouched. Say the word if you want it removed.