### PR TITLE
fix(release): stop rewriting tags; order versions by the actual scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,17 @@ jobs:
           # On workflow_dispatch (no tag) fall back to today's date.
           if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF_NAME}"
-            # Strip optional leading 'v' and ensure -0 release suffix.
-            BASE="${TAG#v}"
-            BASE="${BASE%%-*}"   # drop any existing suffix
-            VER="${BASE}-0"
+            # The tag is the version. Only the optional leading 'v' is removed.
+            #
+            # This used to do `BASE="${BASE%%-*}"; VER="${BASE}-0"`, which threw
+            # away whatever suffix was tagged: 2026.7.29-1 built as 2026.7.29-0,
+            # so a same-day hotfix silently rebuilt the version it was fixing and
+            # the updater offered nothing. An -rc1 tag — advertised as supported
+            # in the trigger comment above — shipped numbered as the stable
+            # release.
+            VER="${TAG#v}"
+            # A bare date tag means the first stable release of that date.
+            [[ "$VER" == *-* ]] || VER="${VER}-0"
           else
             VER="$(calver_release)"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ follows [Calendar Versioning](https://calver.org/) (`YYYY.M.D`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A same-day hotfix release is possible again.** The release workflow
+  discarded whatever suffix a tag carried and forced `-0`, so tagging
+  `2026.7.29-1` rebuilt it as `2026.7.29-0` — the same version it was
+  fixing — and the updater saw nothing new to offer. A tag is now used
+  as the version verbatim; only a bare date tag has `-0` appended. This
+  also fixes `-rc1` tags, which the workflow advertised as supported and
+  then shipped numbered as the stable release.
+- **Switching from the dev channel back to stable no longer claims you
+  are up to date.** Update checks compared versions with plain semver,
+  which ranks numeric pre-release identifiers below alphanumeric ones —
+  so it considered a stable `2026.7.29-1` *older* than a dev build
+  `2026.7.29-dev.1`, and a machine on a dev build was told it was
+  current while running unreleased code. Comparison now understands the
+  release scheme: newer date wins, then a stable release beats a dev
+  build of the same date, then the higher build number.
+
+### Changed
+
+- Dev builds are now versioned `YYYY.M.D-dev.N` instead of `YYYY.M.D-N`,
+  so a version string says which channel it came from. Previously a
+  stable hotfix and a dev build on the same date could produce the same
+  version string for two different builds.
+
 ## [2026.7.29]
 
 ### Fixed

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -3,27 +3,53 @@
 # Shared version utilities for dev builds and releases.
 # Source this file; do not execute directly.
 #
-# Version format: YYYY.M.D-N[-branch-slug]
+# Version format: YYYY.M.D-<suffix>
 #   YYYY.M.D      — CalVer date (no leading zeros; Tauri enforces strict semver)
-#   -0            — stable release suffix
-#   -1, -2 …      — dev build suffix (auto-increments per day, global across branches)
-#   -branch-slug  — present when built from a non-main branch; stripped of common
-#                   prefixes (feature/, fix/, chore/, etc.) and normalized to
-#                   lowercase alphanumeric + hyphens, max 24 chars
+#   -0, -1, -2 …  — stable release; the number increments for a second (hotfix)
+#                   release on the same date
+#   -dev.N        — dev build (auto-increments per day, global across branches)
+#   -branch-slug  — appended to a dev version when built from a non-main branch;
+#                   stripped of common prefixes (feature/, fix/, chore/, etc.)
+#                   and normalized to lowercase alphanumeric + hyphens, max 24
+#
+# The `dev.` prefix exists so a version string identifies its channel. Without
+# it, stable `-1` and dev `-1` on the same date are the same string describing
+# two different artifacts.
+#
+# NOTE ON ORDERING: raw semver gets this wrong, deliberately so, and we override
+# it rather than bend the scheme around it. Semver ranks numeric prerelease
+# identifiers BELOW alphanumeric ones, so it considers 2026.7.29-1 (stable) to
+# be older than 2026.7.29-dev.1. Left alone, a machine on a dev build that
+# switched to the stable channel would be told it was already up to date.
+#
+# tauri-plugin-updater exposes `UpdaterBuilder::version_comparator`, which
+# replaces the `remote > current` test outright. src-tauri/src/updater.rs
+# installs one that parses this scheme — date first, then channel (stable beats
+# dev on the same date), then the counter. That is the single source of truth
+# for "is this an update"; semver ordering of these strings is not relied on
+# anywhere. See the tests in that module.
 
 # Emit YYYY.M.D from the current system clock.
 calver_today() {
   node -p "const d=new Date(); \`\${d.getFullYear()}.\${d.getMonth()+1}.\${d.getDate()}\`"
 }
 
-# Emit the stable release version for today: YYYY.M.D-0
+# Emit the first stable release version for today: YYYY.M.D-0
+#
+# Only the fallback for a tagless workflow_dispatch build. A tag push uses the
+# tag verbatim, so a same-day hotfix is tagged YYYY.M.D-1 by hand rather than
+# guessed at here.
 calver_release() {
   echo "$(calver_today)-0"
 }
 
 # Given the path to a dev-updates/latest.json, emit the next dev version
-# for today (YYYY.M.D-N[-branch-slug]), auto-incrementing N globally across
+# for today (YYYY.M.D-dev.N[-branch-slug]), auto-incrementing N globally across
 # all branches so no two branches collide on the same N for a given day.
+#
+# Reads legacy `YYYY.M.D-N` entries as well as `YYYY.M.D-dev.N`, so a manifest
+# written before the channel prefix existed still advances the counter instead
+# of restarting at 1 and colliding with a build that already shipped.
 calver_next_dev() {
   local manifest="${1:-}"
   local base
@@ -56,7 +82,7 @@ calver_next_dev() {
         const nums = (u.dev || [])
           .map(e => e.version)
           .filter(v => v.startsWith(base + '-'))
-          .map(v => { const m = v.slice(base.length + 1).match(/^(\d+)/); return m ? parseInt(m[1]) : 0; })
+          .map(v => { const m = v.slice(base.length + 1).match(/^(?:dev\.)?(\d+)/); return m ? parseInt(m[1]) : 0; })
           .filter(n => n > 0);
         nums.length ? Math.max(...nums) : 0;
       } catch(e) { 0 }
@@ -68,12 +94,13 @@ calver_next_dev() {
     existing="$(node -p "try{JSON.parse(require('fs').readFileSync('$manifest','utf8')).version}catch(e){''}" 2>/dev/null || echo "")"
     if [[ "$existing" == "${base}-"* ]]; then
       local prev="${existing#${base}-}"
+      prev="${prev#dev.}"     # tolerate both dev.N and the legacy bare N
       prev="${prev%%-*}"
       [[ "$prev" =~ ^[0-9]+$ ]] && counter=$(( prev + 1 ))
     fi
   fi
 
-  echo "${base}-${counter}${branch_slug}"
+  echo "${base}-dev.${counter}${branch_slug}"
 }
 
 # Patch tauri.conf.json, package.json, and Cargo.toml to the given version.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "rustls",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,9 @@ tauri-plugin-updater = "2.0"
 tauri-plugin-process = "2.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Already in the tree via tauri; declared directly so updater.rs can name the
+# type its version_comparator receives.
+semver = "1"
 sha2 = "0.10"
 twox-hash = "2"
 crossbeam-channel = "0.5"

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -106,11 +106,83 @@ fn is_localhost(url: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Where a version sits in the release scheme: the CalVer date, which channel
+/// it belongs to, and its counter within that date.
+///
+/// Ordering is (date, channel, counter) with stable outranking dev on the same
+/// date, which is what you would expect and what plain semver refuses to do.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct Release {
+    date: (u64, u64, u64),
+    /// 0 = dev, 1 = stable. A stable release supersedes every dev build of the
+    /// same date; a dev build never supersedes a stable one.
+    channel: u8,
+    counter: u64,
+}
+
+/// Parse `YYYY.M.D-0` (stable), `YYYY.M.D-dev.N` (dev), or a bare `YYYY.M.D`.
+///
+/// A trailing branch slug on a dev version (`-dev.3-my-branch`) is ignored: two
+/// builds with the same counter from different branches are not meaningfully
+/// ordered against each other, and the dev panel installs by explicit choice
+/// rather than by comparison.
+fn parse_release(v: &semver::Version) -> Release {
+    let date = (v.major, v.minor, v.patch);
+    let pre = v.pre.as_str();
+    if pre.is_empty() {
+        // No suffix at all — treat as the first stable of that date.
+        return Release {
+            date,
+            channel: 1,
+            counter: 0,
+        };
+    }
+    if let Some(rest) = pre.strip_prefix("dev.") {
+        let counter = rest
+            .split(['.', '-'])
+            .next()
+            .and_then(|n| n.parse().ok())
+            .unwrap_or(0);
+        return Release {
+            date,
+            channel: 0,
+            counter,
+        };
+    }
+    // Stable: a bare numeric suffix. Anything unrecognised (an `-rc1`, say)
+    // parses to counter 0, so it never outranks a numbered stable release of
+    // the same date.
+    let counter = pre
+        .split(['.', '-'])
+        .next()
+        .and_then(|n| n.parse().ok())
+        .unwrap_or(0);
+    Release {
+        date,
+        channel: 1,
+        counter,
+    }
+}
+
+/// Replaces tauri's default `remote > current` semver test.
+///
+/// Semver ranks numeric prerelease identifiers below alphanumeric ones, so it
+/// considers `2026.7.29-1` (a stable hotfix) OLDER than `2026.7.29-dev.1`. With
+/// the default comparator, a machine on a dev build that switched to the stable
+/// channel was told it was already up to date while running unreleased code.
+///
+/// This orders by the scheme's actual meaning instead — see scripts/version.sh.
+fn is_newer(current: &semver::Version, remote: &semver::Version) -> bool {
+    parse_release(remote) > parse_release(current)
+}
+
 fn build(
     app: &AppHandle,
     endpoint: Option<String>,
 ) -> Result<tauri_plugin_updater::Updater, String> {
-    let mut b = app.updater_builder();
+    let mut b = app
+        .updater_builder()
+        .version_comparator(|current, release| is_newer(&current, &release.version));
     let local = endpoint.as_deref().map(is_localhost).unwrap_or(false);
     if let Some(url) = endpoint {
         let parsed = Url::parse(&url).map_err(|e| format!("bad endpoint URL: {e}"))?;
@@ -185,4 +257,97 @@ pub async fn updater_fetch_updates(endpoint: String) -> Result<Vec<UpdateEntry>,
         .map_err(|e| format!("updates parse failed: {e}"))?;
 
     Ok(manifest.dev.into_iter().take(10).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> semver::Version {
+        semver::Version::parse(s).unwrap_or_else(|e| panic!("{s} must be valid semver: {e}"))
+    }
+
+    /// Every version this scheme emits has to survive semver parsing, because
+    /// tauri stores it as a `semver::Version` before we ever see it.
+    #[test]
+    fn every_scheme_version_is_valid_semver() {
+        for s in [
+            "2026.7.29-0",
+            "2026.7.29-1",
+            "2026.7.29-12",
+            "2026.7.29-dev.1",
+            "2026.7.29-dev.42",
+            "2026.7.29-dev.3-my-branch",
+            "2026.7.29",
+        ] {
+            let _ = v(s);
+        }
+    }
+
+    #[test]
+    fn a_same_day_hotfix_is_an_update() {
+        assert!(is_newer(&v("2026.7.29-0"), &v("2026.7.29-1")));
+        assert!(is_newer(&v("2026.7.29-1"), &v("2026.7.29-2")));
+        assert!(!is_newer(&v("2026.7.29-2"), &v("2026.7.29-1")));
+    }
+
+    /// The bug this comparator exists for. Plain semver ranks numeric
+    /// prerelease identifiers below alphanumeric ones, so it puts the stable
+    /// hotfix BELOW the dev build and reports "up to date".
+    #[test]
+    fn stable_supersedes_a_dev_build_of_the_same_date() {
+        assert!(is_newer(&v("2026.7.29-dev.9"), &v("2026.7.29-1")));
+        assert!(!is_newer(&v("2026.7.29-1"), &v("2026.7.29-dev.9")));
+
+        // Confirm raw semver really does disagree — if this ever stops being
+        // true, the comparator is no longer earning its keep.
+        assert!(
+            v("2026.7.29-1") < v("2026.7.29-dev.9"),
+            "semver ordering changed; re-evaluate whether the comparator is needed"
+        );
+    }
+
+    #[test]
+    fn a_later_date_always_wins() {
+        assert!(is_newer(&v("2026.7.29-9"), &v("2026.7.30-0")));
+        assert!(is_newer(&v("2026.7.29-dev.9"), &v("2026.7.30-dev.1")));
+        assert!(is_newer(&v("2026.12.31-0"), &v("2027.1.1-0")));
+        assert!(!is_newer(&v("2026.7.30-0"), &v("2026.7.29-9")));
+    }
+
+    #[test]
+    fn dev_builds_advance_among_themselves() {
+        assert!(is_newer(&v("2026.7.29-dev.1"), &v("2026.7.29-dev.2")));
+        assert!(!is_newer(&v("2026.7.29-dev.2"), &v("2026.7.29-dev.1")));
+    }
+
+    #[test]
+    fn a_branch_slug_does_not_change_the_ordering() {
+        assert!(is_newer(
+            &v("2026.7.29-dev.1-some-branch"),
+            &v("2026.7.29-dev.2")
+        ));
+        assert!(is_newer(
+            &v("2026.7.29-dev.3-some-branch"),
+            &v("2026.7.29-0")
+        ));
+    }
+
+    #[test]
+    fn the_same_version_is_never_an_update() {
+        for s in ["2026.7.29-0", "2026.7.29-dev.4", "2026.7.29"] {
+            assert!(!is_newer(&v(s), &v(s)), "{s} should not update to itself");
+        }
+    }
+
+    /// Legacy dev builds predate the `dev.` prefix and read as stable under
+    /// this parser. That is deliberate: the alternative is guessing, and
+    /// treating an unknown numeric suffix as stable keeps a real stable
+    /// release from being withheld.
+    #[test]
+    fn a_bare_date_counts_as_the_first_stable_of_that_date() {
+        assert!(is_newer(&v("2026.7.29-dev.5"), &v("2026.7.29")));
+        assert!(!is_newer(&v("2026.7.29"), &v("2026.7.29-0")));
+        assert!(is_newer(&v("2026.7.29"), &v("2026.7.29-1")));
+    }
 }

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -1400,6 +1400,12 @@ function ReleaseNotes({ markdown }) {
   );
 }
 
+/// UNUSED — no call sites. Left in place rather than deleted, but do not wire
+/// it up: it splits on the first `-` and runs the remainder through Number(),
+/// so a dev version yields Number("dev.1") === NaN and every comparison against
+/// it is false. "Is this an update" is decided by the version_comparator in
+/// src-tauri/src/updater.rs, which is the only implementation that understands
+/// the channel scheme, and it is covered by tests there.
 function calverGt(a, b) {
   const parse = v => { const [date, n = '0'] = v.split('-'); const [y, m, d] = date.split('.').map(Number); return [y, m, d, Number(n)]; };
   const pa = parse(a), pb = parse(b);


### PR DESCRIPTION
Two bugs together made a same-day hotfix impossible.

### 1. The workflow discarded what you tagged

```bash
BASE="${BASE%%-*}"   # drop any existing suffix
VER="${BASE}-0"
```

Tag `2026.7.29-1` → built as `2026.7.29-0`. Byte-identical version to the
release it was fixing, so the updater had nothing newer to offer. The same line
silently shipped `-rc1` tags numbered as the **stable** release — despite the
trigger comment directly above advertising `2026.5.12-rc1` as supported.

A tag is now the version verbatim; only a bare date tag gets `-0` appended:

| tag | version |
|---|---|
| `2026.7.29` | `2026.7.29-0` |
| `2026.7.29-1` | `2026.7.29-1` ← was `-0` |
| `2026.7.29-2` | `2026.7.29-2` |
| `v2026.7.30` | `2026.7.30-0` |
| `2026.5.12-rc1` | `2026.5.12-rc1` ← was `-0` |

### 2. Semver orders this scheme backwards

Semver ranks numeric pre-release identifiers **below** alphanumeric ones, so:

```
2026.7.29-1  <  2026.7.29-dev.1     # stable hotfix ranked below a dev build
```

With tauri's default comparator, a machine on a dev build that switched to the
stable channel was told it was up to date while running unreleased code.

Rather than bending the version scheme around that ordering,
`UpdaterBuilder::version_comparator` replaces the `remote > current` test
outright — a supported hook, no fork:

```rust
let should_update = match self.version_comparator.as_ref() {
    Some(comparator) => comparator(self.current_version.clone(), release.clone()),
    None => release.version > self.current_version,   // ← only the fallback
};
```

`updater.rs` now orders by what the scheme means: **date → channel → counter**,
with stable beating dev on the same date.

### 3. Dev builds name their channel

`YYYY.M.D-N` → `YYYY.M.D-dev.N`. Without it, a stable hotfix `-1` and a dev
build `-1` on the same date are the same string describing two different
artifacts — ambiguous in bug reports and in the manifests.

The dev counter parser reads both forms, so an existing `updates.json` keeps
advancing instead of restarting at 1 and colliding with a build already shipped.

### Tests

8 tests on the comparator: same-day hotfix, stable-beats-dev, date precedence,
dev sequencing, branch slugs, identity. One of them asserts that **raw semver
disagrees** — so if someone later removes the comparator as redundant, a test
fails and tells them why it exists.

### Also

`calverGt` in `components.jsx` is dead code (no call sites) that would mis-parse
dev versions — `Number("dev.1")` is `NaN`, making every comparison false. Left
in place, marked do-not-use, pointed at the Rust comparator. Happy to delete it
instead if you'd rather.