### PR TITLE
chore(doctor): remove the unused probe_binary helper

### DIFF
--- a/src-tauri/src/doctor.rs
+++ b/src-tauri/src/doctor.rs
@@ -14,7 +14,6 @@
 
 #[cfg(target_os = "macos")]
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use serde::Serialize;
 
@@ -98,30 +97,6 @@ pub fn aggregate(checks: &[Check]) -> CheckStatus {
         }
     }
     overall
-}
-
-/// Best-effort: return the first line of `<bin> --version` if the
-/// binary is on $PATH and exits 0. None otherwise.
-///
-/// **Not an existence test.** `None` means "did not answer `--version` with
-/// exit 0", which is also what a perfectly present verb-based tool returns —
-/// `diskutil --version` exits 1 with `did not recognize verb`. Using this to
-/// decide whether a tool is installed reported a macOS built-in as missing.
-/// For "is it installed", use [`crate::toolpath::resolve`], which looks
-/// instead of executing and searches beyond the minimal PATH a GUI app gets.
-pub fn probe_binary(bin: &str) -> Option<String> {
-    let out = Command::new(bin)
-        .arg("--version")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let s = String::from_utf8_lossy(&out.stdout);
-    s.lines().next().map(|s| s.trim().to_string())
 }
 
 /// Defers to [`crate::qemu::detect`] rather than probing separately, so the
@@ -366,18 +341,6 @@ mod tests {
         assert_eq!(c.name, "Long Name");
         assert_eq!(c.category, "feature");
         assert_eq!(c.note, "explanation");
-    }
-
-    #[test]
-    fn probe_binary_returns_none_for_missing_command() {
-        assert!(probe_binary("disk-cutter-this-binary-cannot-exist-abc123").is_none());
-    }
-
-    #[test]
-    fn probe_binary_returns_first_line_for_real_command() {
-        // `cat --version` works on macOS + most Linuxes; if not present
-        // we accept either Some(_) or None as "didn't crash".
-        let _ = probe_binary("cat");
     }
 
     #[test]


### PR DESCRIPTION
Nothing has called `doctor::probe_binary` since `check_qemu` started deferring
to `qemu::detect()` and the eject checks moved to `toolpath::resolve`. It was
left in place with a doc comment warning against reusing it.

Removing it is the stronger version of that warning. The helper decided whether
a tool existed by running `<bin> --version` and requiring exit 0, which reports
any verb-based CLI as missing:

```
$ diskutil --version
diskutil: did not recognize verb "--version"
$ echo $?
1
```

That's how a macOS built-in got diagnosed as absent with the user's PATH blamed
for it. `toolpath::resolve` is the only existence check now, and it looks rather
than executes.

Also drops `std::process::{Command, Stdio}` — this was its sole user in the
module — and the two tests that only exercised the removed function.

### Kept deliberately

`qemu.rs` has its own `probe_binary`, still used and legitimately so: it reads a
version string **for display** from a path already resolved by `toolpath`,
rather than using the run to decide whether the binary is there. That
distinction was the entire bug, so the two are worth keeping separate.

37 lines removed. clippy clean with `-D warnings` (the unused import would
otherwise fail CI).